### PR TITLE
Confirm carthage can pull/build Lucid in both Debug and Release mode.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,36 @@ jobs:
     env: 
       DEVELOPER_DIR: /Applications/Xcode_11.2.1.app/Contents/Developer
       GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      CARTHAGE_DEBUG_OUTPUT: /tmp/carthage_debug_output.txt
+      CARTHAGE_RELEASE_OUTPUT: /tmp/carthage_release_output.txt
+      CARTHAGE_LOGS: CarthageLogs
 
     steps:
       - name: Build Lucid Framework Using Carthage
         run: |
           echo 'git "git@github.com:scribd/Lucid.git" "master"' > Cartfile
           
-          carthage bootstrap --platform iOS,watchOS --configuration Debug
-          carthage bootstrap --platform iOS,watchOS --configuration Release
+          carthage bootstrap --platform iOS,watchOS --configuration Debug 2>&1 | tee $CARTHAGE_DEBUG_OUTPUT
+          carthage bootstrap --platform iOS,watchOS --configuration Release 2>&1 | tee $CARTHAGE_RELEASE_OUTPUT
+
+      - name: Consolidate All Log Files
+        if: ${{ always() }}
+        run: |
+          mkdir -p $CARTHAGE_LOGS
+
+          CARTHAGE_DEBUG_LOGS=`grep "xcodebuild\ output\ can\ be\ found\ in\ *" $CARTHAGE_DEBUG_OUTPUT | awk '{ print $NF }'`
+          while IFS= read -r line ; do 
+            cp $line $CARTHAGE_LOGS
+          done <<< "$CARTHAGE_DEBUG_LOGS"
+
+          CARTHAGE_RELEASE_LOGS=`grep "xcodebuild\ output\ can\ be\ found\ in\ *" $CARTHAGE_RELEASE_OUTPUT | awk '{ print $NF }'`
+          while IFS= read -r line ; do 
+            cp $line $CARTHAGE_LOGS
+          done <<< "$CARTHAGE_RELEASE_LOGS"
+
+      - name: Upload Log Files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-log
+          path: ${{ env.CARTHAGE_LOGS }}


### PR DESCRIPTION
### Note: Recommend reviewing commit by commit

The build logs are uploaded as artifacts in the run. This allows them to be downloaded and inspected if Carthage fails.

<img width="1033" alt="Screen Shot 2020-07-22 at 2 32 28 PM" src="https://user-images.githubusercontent.com/662419/88225939-92179a80-cc28-11ea-8d91-6dc026e1148d.png">

<img width="1256" alt="Screen Shot 2020-07-22 at 2 31 44 PM" src="https://user-images.githubusercontent.com/662419/88225639-1289cb80-cc28-11ea-8f16-1fe7d3ca65e7.png">
