### PR TITLE
Move model renaming into the `version_history` object. CodeGen now in…

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Core/Descriptions.swift
+++ b/CodeGen/Sources/LucidCodeGen/Core/Descriptions.swift
@@ -95,6 +95,8 @@ public protocol Descriptions {
     var endpointsByName: [String: EndpointPayload] { get }
     
     var targets: Targets { get }
+
+    var version: Version { get }
 }
 
 // MARK: - EndpointPayload
@@ -218,8 +220,6 @@ public struct Entity {
     
     public let persistedName: String?
     
-    public let previousName: String?
-    
     public let platforms: Set<Platform>
     
     public let remote: Bool
@@ -233,7 +233,11 @@ public struct Entity {
     public var properties: [EntityProperty]
     
     public let identifierTypeID: String?
-    
+
+    public let legacyPreviousName: String?
+
+    public let legacyAddedAtVersion: Version?
+
     public let versionHistory: [VersionHistoryItem]
     
     public let lastRemoteRead: Bool
@@ -248,6 +252,8 @@ public struct Entity {
 public struct VersionHistoryItem: Equatable {
 
     public let version: Version
+
+    public let previousName: String?
 
     public let ignoreMigrationChecks: Bool
 
@@ -484,7 +490,7 @@ public struct Version: Hashable, Comparable, CustomStringConvertible {
     let minor: Int
     let patch: Int?
     let build: Int?
-    
+
     public init(_ versionString: String, source: Source) throws {
         let version = try Version.matchesForVersionComponents(source.versionComponents, in: versionString)
         guard let major = version.major, let minor = version.minor else {
@@ -548,6 +554,17 @@ public struct Version: Hashable, Comparable, CustomStringConvertible {
             return "\(major)_\(minor)"
         }
     }
+
+    private init(major: Int, minor: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = nil
+        self.build = nil
+        self.tag = .other
+        self.versionString = String()
+    }
+
+    public static var zeroVersion: Version { return Version(major: 0, minor: 0) }
 }
 
 private extension Version {

--- a/CodeGen/Sources/LucidCodeGen/Generators/CoreDataMigrationTestsGenerator.swift
+++ b/CodeGen/Sources/LucidCodeGen/Generators/CoreDataMigrationTestsGenerator.swift
@@ -20,7 +20,9 @@ public final class CoreDataMigrationTestsGenerator: Generator {
     private let sqliteFiles: [String]
     
     private let appVersion: Version
-    
+
+    private let oldestModelVersion: Version
+
     private let platform: Platform?
 
     private let reactiveKit: Bool
@@ -28,12 +30,14 @@ public final class CoreDataMigrationTestsGenerator: Generator {
     public init(descriptions: Descriptions,
                 sqliteFiles: [String],
                 appVersion: Version,
+                oldestModelVersion: Version,
                 platform: Platform?,
                 reactiveKit: Bool) {
         
         self.descriptions = descriptions
         self.sqliteFiles = sqliteFiles
         self.appVersion = appVersion
+        self.oldestModelVersion = oldestModelVersion
         self.platform = platform
         self.reactiveKit = reactiveKit
     }
@@ -45,11 +49,13 @@ public final class CoreDataMigrationTestsGenerator: Generator {
 
         let sqliteVersions = sqliteFiles
             .compactMap { try? Version($0, source: .coreDataModel) }
+            .filter { $0 > oldestModelVersion || Version.isMatchingRelease($0, oldestModelVersion) }
             .sorted()
 
         let coreDataMigrationTests = MetaCoreDataMigrationTests(descriptions: descriptions,
                                                                 sqliteVersions: sqliteVersions,
                                                                 appVersion: appVersion,
+                                                                oldestModelVersion: oldestModelVersion,
                                                                 platform: platform,
                                                                 reactiveKit: reactiveKit)
         

--- a/CodeGen/Sources/LucidCommand/Descriptions.swift
+++ b/CodeGen/Sources/LucidCommand/Descriptions.swift
@@ -13,7 +13,7 @@ import PathKit
 // MARK: - Descriptions
 
 final class Descriptions: LucidCodeGen.Descriptions {
-    
+
     let subtypes: [Subtype]
     let entities: [Entity]
     let endpoints: [EndpointPayload]
@@ -25,12 +25,15 @@ final class Descriptions: LucidCodeGen.Descriptions {
     let persistedEntitiesByName: [String: Entity]
     
     let targets: Targets
-    
+
+    let version: Version
+
     private init(subtypes: [Subtype],
                  entities: [Entity],
                  endpoints: [EndpointPayload],
-                 targets: Targets) {
-        
+                 targets: Targets,
+                 version: Version) {
+
         self.subtypes = subtypes
         self.entities = entities
         self.endpoints = endpoints
@@ -45,14 +48,15 @@ final class Descriptions: LucidCodeGen.Descriptions {
             .reduce(into: [:]) { $0[$1.name] = $1 }
 
         self.targets = targets
+        self.version = version
     }
     
-    fileprivate convenience init(_ parser: DescriptionsParser, _ targets: Targets) throws {
+    fileprivate convenience init(_ parser: DescriptionsParser, _ targets: Targets, _ version: Version) throws {
         let subtypes: [Subtype] = try parser.parseDescription(.subtypes).sorted { $0.name < $1.name }
         let entities: [Entity] = try parser.parseDescription(.entities).sorted { $0.name < $1.name }
         let endpoints: [EndpointPayload] = try parser.parseDescription(.endpointPayloads).sorted { $0.name < $1.name }
 
-        self.init(subtypes: subtypes, entities: entities, endpoints: endpoints, targets: targets)
+        self.init(subtypes: subtypes, entities: entities, endpoints: endpoints, targets: targets, version: version)
     }
     
     func variant(for platform: Platform) -> Descriptions {
@@ -94,7 +98,8 @@ final class Descriptions: LucidCodeGen.Descriptions {
             subtypes: subtypes,
             entities: entities,
             endpoints: endpoints,
-            targets: targets
+            targets: targets,
+            version: version
         )
     }
 
@@ -170,9 +175,9 @@ final class DescriptionsParser {
         self.logger = logger
     }
     
-    func parse() throws -> Descriptions {
+    func parse(version: Version) throws -> Descriptions {
         logger.moveToChild("Parsing Descriptions.")
-        let descriptions = try Descriptions(self, targets)
+        let descriptions = try Descriptions(self, targets, version)
         logger.moveToParent()
         return descriptions
     }

--- a/Lucid/Core/Version.swift
+++ b/Lucid/Core/Version.swift
@@ -42,7 +42,7 @@ public struct Version: Comparable, CustomStringConvertible {
         return false
     }
 
-    static var oldestVersion: Version { return Version(major: 9, minor: 5, patch: 0) }
+    static var oldestVersion: Version { return Version(major: 0, minor: 0, patch: nil) }
 
     public var description: String {
         if let patch = patch {


### PR DESCRIPTION
…spects the existing model history to determine the oldest model to build migration tests for, deleting old models and re-running CodeGen will now adjust accordingly.

This change handles the issue of renaming between versions. The `previous_name` field has been moved into the `version_history` property.  The old `previous_name` field has been renamed to `legacy_ previous_name` and will no longer be required for future versions.

Since the `element_id` of a CoreData entity can never be changed once it is set, the first `previous_name` field is always used to determine the `"element_id"` value. However, we can now use the version history to identify multiple name changes over time, which allows us to correctly remove the previous entity definition from the data model to allow the migration to perform correctly using the new migration name.

Additionally, this PR adds a new value `oldestMigrationVersion` which it determines by parsing the `Support/DataLayer.xcdatamodeld` directory. If the user has trimmed old values, it will remove those versions from the migration tests and adjust any guarding `if` statements as necessary.