### PR TITLE
Add more granularity to Network errors. Add more nuanced support to the APIClientQueue regarding request timeouts.

### DIFF
--- a/Lucid/Core/CoreManager.swift
+++ b/Lucid/Core/CoreManager.swift
@@ -617,7 +617,7 @@ private extension CoreManager {
                     } else {
                         return self.get(withQuery: query, in: remoteContext)
                             .flatMapError { error -> Signal<QueryResult<E>, ManagerError> in
-                                if error.isNetworkConnectionFailure {
+                                if error.isInternetConnectionFailure {
                                     // if we can't reach the remote store, return local results
                                     return Signal(just: localResult)
                                 } else {
@@ -725,7 +725,7 @@ private extension CoreManager {
 
             let overwriteSearch: (QueryResult<E>?) -> Signal<QueryResult<E>, ManagerError> = { localResult in
                 let mapNetworkErrorToLocalResult: ((ManagerError) -> Signal<QueryResult<E>, ManagerError>) = { error in
-                    if error.isNetworkConnectionFailure, let localResult = localResult {
+                    if error.isInternetConnectionFailure, let localResult = localResult {
                         // if we can't reach the remote store, return local results
                         return Signal(just: localResult)
                     } else {
@@ -878,7 +878,7 @@ private extension CoreManager {
                         }
 
                     case .failure(let error):
-                        Logger.log(.error, "\(CoreManager.self): An error occurred while searching entities: \(error)", assert: error.isNetworkConnectionFailure == false)
+                        Logger.log(.error, "\(CoreManager.self): An error occurred while searching entities: \(error)", assert: error.isInternetConnectionFailure == false)
                         guardedPromise(.failure(.store(error)))
                     }
                 }

--- a/Lucid/Utils/Signal.swift
+++ b/Lucid/Utils/Signal.swift
@@ -146,7 +146,7 @@ public extension APIError {
 
     var isNetworkConnectionFailure: Bool {
         switch self {
-        case .internetConnectionFailure:
+        case .network(.networkConnectionFailure):
             return true
         case .api,
              .deserialization,

--- a/LucidTests/Core/APIClientQueueTests.swift
+++ b/LucidTests/Core/APIClientQueueTests.swift
@@ -578,16 +578,16 @@ extension APIClientQueueTests {
 
         let localIdentifierData = "[{\"local\":\"1\"}]".data(using: .utf8)
 
-        let config0 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: true))
+        let config0 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: [.onNetworkInterrupt]))
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(config0), identifiers: localIdentifierData)
 
-        let config1 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: false))
+        let config1 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(config1), identifiers: localIdentifierData)
 
-        let config2 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: true))
+        let config2 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: [.onNetworkInterrupt]))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(config2), identifiers: localIdentifierData)
 
-        let config3 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: false))
+        let config3 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request3 = APIClientQueueRequest(wrapping: APIRequest<Data>(config3), identifiers: localIdentifierData)
 
         defaultQueue.append(request0)
@@ -595,7 +595,7 @@ extension APIClientQueueTests {
         defaultQueue.append(request2)
         defaultQueue.append(request3)
 
-        let removedRequests = defaultQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryOnInternetConnectionFailure == false })
+        let removedRequests = defaultQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
 
         // test correct requests were removed
         XCTAssertEqual(removedRequests.count, 2)
@@ -616,16 +616,16 @@ extension APIClientQueueTests {
     func test_remove_requests_should_remove_every_request_matching_the_filter_in_the_uniquing_queue() {
 
 
-        let config0 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: true))
+        let config0 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: [.onNetworkInterrupt]))
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(config0), identifiers: "[{\"local\":\"1\"}]".data(using: .utf8))
 
-        let config1 = APIRequestConfig(method: .get, path: .path("fake_path2"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: false))
+        let config1 = APIRequestConfig(method: .get, path: .path("fake_path2"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(config1), identifiers: "[{\"local\":\"2\"}]".data(using: .utf8))
 
-        let config2 = APIRequestConfig(method: .get, path: .path("fake_path3"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: true))
+        let config2 = APIRequestConfig(method: .get, path: .path("fake_path3"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: [.onNetworkInterrupt]))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(config2), identifiers: "[{\"local\":\"3\"}]".data(using: .utf8))
 
-        let config3 = APIRequestConfig(method: .get, path: .path("fake_path4"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryOnInternetConnectionFailure: false))
+        let config3 = APIRequestConfig(method: .get, path: .path("fake_path4"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request3 = APIClientQueueRequest(wrapping: APIRequest<Data>(config3), identifiers: "[{\"local\":\"4\"}]".data(using: .utf8))
 
         uniquingQueue.append(request0)
@@ -633,7 +633,7 @@ extension APIClientQueueTests {
         uniquingQueue.append(request2)
         uniquingQueue.append(request3)
 
-        let removedRequests = uniquingQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryOnInternetConnectionFailure == false })
+        let removedRequests = uniquingQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
 
         // test correct requests were removed
         XCTAssertEqual(removedRequests.count, 2)

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -4267,7 +4267,7 @@ final class CoreManagerTests: XCTestCase {
     // MARK: get: local --> remote
 
     func test_get_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error() {
-        remoteStoreSpy.getResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.getResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.getResultStub = .success(.entities([]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
@@ -4303,7 +4303,7 @@ final class CoreManagerTests: XCTestCase {
     }
 
     func test_get_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error() {
-        remoteStoreSpy.getResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.getResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.getResultStub = .success(.entities([]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
@@ -4341,7 +4341,7 @@ final class CoreManagerTests: XCTestCase {
     // MARK: search: local --> remote
 
     func test_search_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error() {
-        remoteStoreSpy.searchResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.searchResultStub = .success(.entities([]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
@@ -4378,7 +4378,7 @@ final class CoreManagerTests: XCTestCase {
     }
 
     func test_search_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error() {
-        remoteStoreSpy.searchResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.searchResultStub = .success(.entities([]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
@@ -4415,7 +4415,7 @@ final class CoreManagerTests: XCTestCase {
     }
 
     func test_search_local_or_remote_returns_partial_local_result_when_receiving_internet_connection_error() {
-        remoteStoreSpy.searchResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
@@ -4454,7 +4454,7 @@ final class CoreManagerTests: XCTestCase {
     }
 
     func test_search_local_then_remote_returns_partial_local_result_when_receiving_internet_connection_error() {
-        remoteStoreSpy.searchResultStub = .failure(.api(.internetConnectionFailure(NSError(domain: "test", code: 0, userInfo: nil))))
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
         memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
 
         let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")


### PR DESCRIPTION
The primary goal here is to have the APIClientQueue handle a request timeout separately from a loss of network connection.

One of the changes previously added to the client queue was to quickly fail any non-barrier, non-retry requests that were sitting in the queue behind a barrier operation whenever any active request had an internet connection error. The reason for this was to allow requests waiting on both local and remote store responses to not hang indefinitely. 

This logic is sound with the exception that it was also triggered by request timeouts. A timeout could caused by many things other than not being connected to the internet/network. 

I've added logic to the processor to treat timeouts differently, as well as adding a separate flag to the QueueingStrategy to allow specifically requesting to be retried on a timeout. (this defaults to `false` for GETs, etc and `true` for POSTs, etc).

As part of this MR I've taken a swing at more explicitly defining the error `APIError.Network` and sub groupings where they seemed useful. This breakdown is very arbitrary and could probably use additional eyes.