### PR TITLE
Make the concrete logger internal

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaCoreDataMigrationTests.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaCoreDataMigrationTests.swift
@@ -80,12 +80,12 @@ struct MetaCoreDataMigrationTests {
 
             override func setUp() {
                 super.setUp()
-                Logger.shared = LoggerMock()
+                LucidConfiguration.logger = LoggerMock()
             }
             
             override func tearDown() {
                 defer { super.tearDown() }
-                Logger.shared = nil
+                LucidConfiguration.logger = nil
             }
 
             private func runTest(for sqliteFile: String, version: Version) throws {

--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityCoreDataTests.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityCoreDataTests.swift
@@ -40,7 +40,7 @@ struct MetaEntityCoreDataTests {
             override func setUp() {
                 super.setUp()
             
-                Logger.shared = LoggerMock()
+                LucidConfiguration.logger = LoggerMock()
                 store = CoreDataStore(coreDataManager: CoreDataManager(modelName: "\(descriptions.targets.app.moduleName)",
                                                                        in: Bundle(for: CoreManagerContainer.self),
                                                                        storeType: .memory))
@@ -50,7 +50,7 @@ struct MetaEntityCoreDataTests {
                 defer { super.tearDown() }
 
                 store = nil
-                Logger.shared = nil
+                LucidConfiguration.logger = nil
             }
             
             // MARK: - Tests

--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaExportSQLiteFileTest.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaExportSQLiteFileTest.swift
@@ -57,13 +57,13 @@ struct MetaExportSQLiteFileTest {
             override func setUp() {
                 super.setUp()
                 
-                Logger.shared = LoggerMock()
+                LucidConfiguration.logger = LoggerMock()
             }
                 
             override func tearDown() {
                 defer { super.tearDown() }
                 
-                Logger.shared = nil
+                LucidConfiguration.logger = nil
             }
                 
             func test_populate_database_and_export_sqlite_file() throws {

--- a/Lucid/Utils/Logger.swift
+++ b/Lucid/Utils/Logger.swift
@@ -48,42 +48,45 @@ extension Logging {
     }
 }
 
-@objc public final class Logger: NSObject {
 
-    private static var _shared: Logging? = DefaultLogger()
-    private static let dispatchQueue = DispatchQueue(label: "\(Logger.self):shared", attributes: .concurrent)
+private var _logger: Logging? = DefaultLogger()
+private let dispatchQueue = DispatchQueue(label: "\(Logger.self):shared", attributes: .concurrent)
 
-    @objc(sharedLogger)
-    public static var shared: Logging? {
+public extension LucidConfiguration {
+
+    static var logger: Logging? {
         get {
-            return dispatchQueue.sync { _shared }
+            return dispatchQueue.sync { _logger }
         }
         set {
             dispatchQueue.async(flags: .barrier) {
-                self._shared = newValue
+                _logger = newValue
             }
         }
     }
+}
 
-    public static func log(_ type: LogType,
-                           _ message: @autoclosure () -> String,
-                           domain: String,
-                           assert: Bool = false,
-                           file: String = #file,
-                           function: String = #function,
-                           line: UInt = #line) {
+final class Logger: NSObject {
 
-        shared?.log(type,
-                    message(),
-                    domain: domain,
-                    assert: assert,
-                    file: file,
-                    function: function,
-                    line: line)
+    static func log(_ type: LogType,
+                    _ message: @autoclosure () -> String,
+                    domain: String,
+                    assert: Bool = false,
+                    file: String = #file,
+                    function: String = #function,
+                    line: UInt = #line) {
+
+        LucidConfiguration.logger?.log(type,
+                                       message(),
+                                       domain: domain,
+                                       assert: assert,
+                                       file: file,
+                                       function: function,
+                                       line: line)
     }
 
-    public static func loggableErrorString(_ error: Error) -> String {
-        return shared?.loggableErrorString(error) ?? String()
+    static func loggableErrorString(_ error: Error) -> String {
+        return LucidConfiguration.logger?.loggableErrorString(error) ?? String()
     }
 }
 

--- a/LucidTestKit/Doubles/EntityRelationshipSpy.swift
+++ b/LucidTestKit/Doubles/EntityRelationshipSpy.swift
@@ -308,7 +308,7 @@ extension EntityRelationshipSpy: CoreDataEntity {
         do {
             return try EntityRelationshipSpy(coreDataEntity: coreDataEntity)
         } catch {
-            Logger.log(.error, "\(EntityRelationshipSpy.self): \(error)", domain: "Tests", assert: true)
+            LucidConfiguration.logger?.log(.error, "\(EntityRelationshipSpy.self): \(error)", domain: "Tests", assert: true)
             return nil
         }
     }

--- a/LucidTestKit/Doubles/EntitySpy.swift
+++ b/LucidTestKit/Doubles/EntitySpy.swift
@@ -366,7 +366,7 @@ extension EntitySpy: CoreDataEntity {
         do {
             return try EntitySpy(coreDataEntity: coreDataEntity)
         } catch {
-            Logger.log(.error, "\(EntitySpy.self): \(error)", domain: "Tests", assert: true)
+            LucidConfiguration.logger?.log(.error, "\(EntitySpy.self): \(error)", domain: "Tests", assert: true)
             return nil
         }
     }

--- a/LucidTests/Core/APIClientQueueDefaultSchedulerTests.swift
+++ b/LucidTests/Core/APIClientQueueDefaultSchedulerTests.swift
@@ -30,7 +30,7 @@ final class APIClientQueueDefaultSchedulerTests: XCTestCase {
         super.setUp()
         dispatchQueue = DispatchQueue(label: "\(APIClientQueueDefaultSchedulerTests.self)")
         timeInterval = 12345
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
         timer = MockTimer()
         timerProvider = MockTimerProvider(timer: timer)
         delegate = APIClientQueueSchedulerDelegateSpy()

--- a/LucidTests/Core/APIClientQueueProcessorTests.swift
+++ b/LucidTests/Core/APIClientQueueProcessorTests.swift
@@ -40,7 +40,7 @@ final class APIClientQueueProcessorTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         clientSpy = APIClientSpy()
         backgroundTaskManagerSpy = BackgroundTaskManagerSpy()

--- a/LucidTests/Core/APIClientQueueTests.swift
+++ b/LucidTests/Core/APIClientQueueTests.swift
@@ -33,7 +33,7 @@ final class APIClientQueueTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         defaultQueueCache = DiskCacheSpy()
         uniquingQueueOrderingCache = DiskCacheSpy()

--- a/LucidTests/Core/CoreManagerContractTests.swift
+++ b/LucidTests/Core/CoreManagerContractTests.swift
@@ -25,7 +25,7 @@ final class CoreManagerContractTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         remoteStoreSpy = StoreSpy()
         remoteStoreSpy.levelStub = .remote

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -26,7 +26,7 @@ final class CoreManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         remoteStoreSpy = StoreSpy()
         remoteStoreSpy.levelStub = .remote

--- a/LucidTests/Core/StoreStackTests.swift
+++ b/LucidTests/Core/StoreStackTests.swift
@@ -22,7 +22,7 @@ final class StoreStackTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         remoteStoreSpy = StoreSpy<EntitySpy>()
         remoteStoreSpy.levelStub = .remote
@@ -453,7 +453,7 @@ final class StoreStackTests: XCTestCase {
 
     func test_should_only_search_in_remote_store_when_order_is_natural() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil))]))
 

--- a/LucidTests/Stores/BaseStoreTests.swift
+++ b/LucidTests/Stores/BaseStoreTests.swift
@@ -28,7 +28,7 @@ class StoreTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
         context = ReadContext<EntitySpy>()
 
         let expectation = self.expectation(description: "set_up")

--- a/LucidTests/Stores/CoreDataStoreTests.swift
+++ b/LucidTests/Stores/CoreDataStoreTests.swift
@@ -35,7 +35,7 @@ final class CoreDataStoreTests: StoreTests {
     }
 
     func test_store_should_not_retrieve_documents_with_an_invalid_expression_equal_to_another_expression() {
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let expectation = self.expectation(description: "documents")
 
@@ -59,7 +59,7 @@ final class CoreDataStoreTests: StoreTests {
     }
 
     func test_store_should_not_retrieve_documents_with_an_invalid_expression_contained_in_another_expression() {
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let expectation = self.expectation(description: "documents")
 
@@ -86,7 +86,7 @@ final class CoreDataStoreTests: StoreTests {
     }
 
     func test_store_should_not_retrieve_documents_with_an_invalid_expression_matched_against_another_expression() {
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let expectation = self.expectation(description: "documents")
 

--- a/LucidTests/Stores/LRUStoreTests.swift
+++ b/LucidTests/Stores/LRUStoreTests.swift
@@ -22,7 +22,7 @@ final class LRUStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         context = ReadContext<EntitySpy>()
         storeSpy = StoreSpy()

--- a/LucidTests/Stores/RemoteStoreTests.swift
+++ b/LucidTests/Stores/RemoteStoreTests.swift
@@ -30,7 +30,7 @@ final class RemoteStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         requestConfig = APIRequestConfig(method: .get, path: .path("fake_entity") / "42")
 
@@ -235,7 +235,7 @@ final class RemoteStoreTests: XCTestCase {
 
     func test_should_fail_to_request_an_entity_from_the_client_using_endpoint_derived_from_entity_type() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         clientQueueSpy.responseStubs[requestConfig] = APIClientQueueResult<Data, APIError>.failure(.api(
             httpStatusCode: 400, errorPayload: nil, response: APIClientResponse(data: Data(), cachedResponse: false)
@@ -561,7 +561,7 @@ final class RemoteStoreTests: XCTestCase {
 
     func test_should_fail_to_search_using_an_entity_from_the_client_when_query_contains_local_identifiers_using_endpoint_derived_from_entity_type() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let localIdentifier = EntitySpyIdentifier(value: .local("local_identifier"))
         requestContext = ReadContext<EntitySpy>(dataSource: .remote(
@@ -742,7 +742,7 @@ final class RemoteStoreTests: XCTestCase {
 
     func test_should_fail_to_request_an_entity_from_the_client_using_request_endpoint() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         clientQueueSpy.responseStubs[requestConfig] = APIClientQueueResult<Data, APIError>.failure(.api(
             httpStatusCode: 400, errorPayload: nil, response: APIClientResponse(data: Data(), cachedResponse: false)
@@ -766,7 +766,7 @@ final class RemoteStoreTests: XCTestCase {
 
     func test_should_fail_to_get_an_entity_from_the_client_when_query_contains_local_identifiers_using_request_endpoint() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let localIdentifier = EntitySpyIdentifier(value: .local("local_identifier"))
         requestContext = ReadContext<EntitySpy>(dataSource: .remote(
@@ -1132,7 +1132,7 @@ final class RemoteStoreTests: XCTestCase {
 
     func test_should_fail_to_search_for_an_entity_from_the_client_when_query_contains_local_identifiers_using_request_endpoint() {
 
-        Logger.shared = LoggerMock(shouldCauseFailures: false)
+        LucidConfiguration.logger = LoggerMock(shouldCauseFailures: false)
 
         let localIdentifier = EntitySpyIdentifier(value: .local("local_identifier"))
         requestContext = ReadContext<EntitySpy>(dataSource: .remote(

--- a/LucidTests/Utils/DiskCacheTests.swift
+++ b/LucidTests/Utils/DiskCacheTests.swift
@@ -21,7 +21,7 @@ final class DiskCacheTests: XCTestCase {
     override func setUp() {
         super.setUp()
         fileManager = FileManager()
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
     }
 
     override func tearDown() {

--- a/LucidTests/Utils/DiskQueueTests.swift
+++ b/LucidTests/Utils/DiskQueueTests.swift
@@ -20,7 +20,7 @@ final class DiskQueueUnitTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         diskCacheSpy = DiskCacheSpy<TestData>()
         diskQueue = DiskQueue(diskCache: diskCacheSpy.caching)
@@ -31,7 +31,7 @@ final class DiskQueueUnitTests: XCTestCase {
 
         diskCacheSpy = nil
         diskQueue = nil
-        Logger.shared = nil
+        LucidConfiguration.logger = nil
     }
 
     func test_should_prepend_elements_in_the_queue() {
@@ -213,7 +213,7 @@ final class DiskQueueIntegrationTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        Logger.shared = LoggerMock()
+        LucidConfiguration.logger = LoggerMock()
 
         diskCache = DiskCache(basePath: "\(DiskQueueIntegrationTests.self)")
         diskCache.clear()
@@ -226,7 +226,7 @@ final class DiskQueueIntegrationTests: XCTestCase {
         diskCache.clear()
         diskCache = nil
         diskQueue = nil
-        Logger.shared = nil
+        LucidConfiguration.logger = nil
     }
 
     func test_should_prepend_elements_in_the_queue_then_drop_them_in_order() {


### PR DESCRIPTION
This avoids a conflict with other frameworks, and the shared var is still available.