### PR TITLE
Context is now passed into `_fill` function, don't override with original context.

### DIFF
--- a/Lucid/Core/RelationshipController.swift
+++ b/Lucid/Core/RelationshipController.swift
@@ -595,7 +595,7 @@ public extension RelationshipController {
                               recursive: RelationshipFetcher.RecursiveMethod = .none,
                               in context: ReadContext? = nil) -> RelationshipQuery {
 
-            fetchers[path] = .all(recursive: recursive, context: context ?? mainContext)
+            fetchers[path] = .all(recursive: recursive, context: context)
             return self
         }
 


### PR DESCRIPTION
When I added Contract support to the RelationshipController I forgot to update this code.

We don't need the original context anymore, as there will be a contextual nested context passed into the `_fill` function.