### PR TITLE
Update the `base_key` field to accept either a single String value or an Array.

### DIFF
--- a/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
@@ -538,27 +538,39 @@ public extension EndpointPayloadEntity.Structure {
     }
 }
 
+public extension ReadWriteEndpointPayload.BaseKey {
+
+    var keys: [String] {
+        switch self {
+        case .single(let key):
+            return [key]
+        case .array(let keys):
+            return keys
+        }
+    }
+}
+
 public extension ReadWriteEndpointPayload {
 
     enum InitializerType {
         case initFromRoot(_ subkey: String?)
-        case initFromKey(_ key: String)
-        case initFromSubkey(key: String, subkey: String)
-        case mapFromSubstruct(key: String, subkey: String)
+        case initFromKeys(_ keys: [String])
+        case initFromSubkey(keys: [String], subkey: String)
+        case mapFromSubstruct(keys: [String], subkey: String)
     }
     
     var initializerType: InitializerType {
 
-        if let key = baseKey, let subkey = entity.entityKey {
+        if let baseKey = baseKey, let subkey = entity.entityKey {
             switch entity.structure {
             case .single,
                  .array:
-                return .initFromSubkey(key: key, subkey: subkey)
+                return .initFromSubkey(keys: baseKey.keys, subkey: subkey)
             case .nestedArray:
-                return .mapFromSubstruct(key: key, subkey: subkey)
+                return .mapFromSubstruct(keys: baseKey.keys, subkey: subkey)
             }
-        } else if let key = baseKey {
-            return .initFromKey(key)
+        } else if let baseKey = baseKey {
+            return .initFromKeys(baseKey.keys)
         } else {
             return .initFromRoot(entity.entityKey)
         }
@@ -584,6 +596,20 @@ public extension ReadWriteEndpointPayload {
         }
 
         return excludedPaths + additionalPaths
+    }
+}
+
+public extension ReadWriteEndpointPayload.InitializerType {
+
+    var keys: [String] {
+        switch self {
+        case .initFromRoot:
+            return []
+        case .initFromKeys(let keys),
+             .initFromSubkey(let keys, _),
+             .mapFromSubstruct(let keys, _):
+            return keys
+        }
     }
 }
 

--- a/CodeGen/Sources/LucidCodeGenCore/Codable.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Codable.swift
@@ -105,7 +105,7 @@ extension ReadWriteEndpointPayload: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: Keys.self)
-        baseKey = try container.decodeIfPresent(String.self, forKey: .baseKey)
+        baseKey = try container.decodeIfPresent(BaseKey.self, forKey: .baseKey)
         entity = try container.decode(EndpointPayloadEntity.self, forKey: .entity)
         entityVariations = try container.decodeIfPresent([EndpointPayloadEntityVariation].self, forKey: .entityVariations)
         excludedPaths = try container.decodeIfPresent([String].self, forKey: .excludedPaths) ?? []
@@ -122,6 +122,28 @@ extension ReadWriteEndpointPayload: Codable {
         try container.encodeIfPresent(excludedPaths.isEmpty ? nil : excludedPaths, forKey: .excludedPaths)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(httpMethod, forKey: .httpMethod)
+    }
+}
+
+extension ReadWriteEndpointPayload.BaseKey: Codable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let arrayBaseKey = try? container.decode([String].self) {
+            self = .array(arrayBaseKey)
+        } else {
+            self = .single(try container.decode(String.self))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .single(let key):
+            try container.encode(key)
+        case .array(let keys):
+            try container.encode(keys)
+        }
     }
 }
 

--- a/CodeGen/Sources/LucidCodeGenCore/Descriptions.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Descriptions.swift
@@ -170,7 +170,12 @@ public struct ReadWriteEndpointPayload: Equatable {
         public static var defaultWrite: HTTPMethod { return .post }
     }
 
-    public let baseKey: String?
+    public enum BaseKey: Equatable {
+        case single(String)
+        case array([String])
+    }
+
+    public let baseKey: BaseKey?
 
     public let entity: EndpointPayloadEntity
 
@@ -182,7 +187,7 @@ public struct ReadWriteEndpointPayload: Equatable {
 
     public let httpMethod: HTTPMethod?
 
-    public init(baseKey: String? = nil,
+    public init(baseKey: BaseKey? = nil,
                 entity: EndpointPayloadEntity,
                 entityVariations: [EndpointPayloadEntityVariation]? = nil,
                 excludedPaths: [String] = [],

--- a/CodeGen/Sources/LucidCodeGenCore/Error.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Error.swift
@@ -21,6 +21,7 @@ public enum CodeGenError: Error, CustomStringConvertible {
     case propertyNotFound(Entity, String)
     case unsupportedPayloadIdentifier
     case unsupportedMetadataIdentifier
+    case expectedValidPayloadKeys
     case unsupportedNestedKeys
     case couldNotFindTargetEntity
     case subtypeDoesNotHaveAnyCase(String)
@@ -63,6 +64,8 @@ public extension CodeGenError {
             return "Unsupported payload identifier."
         case .unsupportedMetadataIdentifier:
             return "Unsupported metadata identifier."
+        case .expectedValidPayloadKeys:
+            return "Expected at least one base_key value."
         case .unsupportedNestedKeys:
             return "Nested keys with more than two levels aren't supported."
         case .couldNotFindTargetEntity:

--- a/CodeGen/Sources/LucidCodeGenCore/MetaUtils.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/MetaUtils.swift
@@ -582,7 +582,14 @@ public extension Reference {
             .adding(parameter: TupleParameter(name: "keyedBy", value: keyType.reference + .named(.`self`)))
         )
     }
-    
+
+    func nestedContainer(keyedBy keyType: TypeIdentifier, forKey key: TypeIdentifier) -> Reference {
+        return self + .named("nestedContainer") | .call(Tuple()
+            .adding(parameter: TupleParameter(name: "keyedBy", value: keyType.reference + .named(.`self`)))
+            .adding(parameter: TupleParameter(name: "forKey", value: +key.reference))
+        )
+    }
+
     static func orderedDualHashDictionary() -> Reference {
         return TypeIdentifier.orderedDualHashDictionary().reference | .call()
     }


### PR DESCRIPTION
This will accommodate data that is nested at a key depth greater than two levels.

It makes sense to have more flexible support for keyPaths of arbitrary depth.