### PR TITLE
Allow individual requests to determine their own url cache policy.

### DIFF
--- a/LucidTests/Core/DataTypeTests.swift
+++ b/LucidTests/Core/DataTypeTests.swift
@@ -40,4 +40,45 @@ final class DataTypeTests: XCTestCase {
             XCTFail("failed with error \(error)")
         }
     }
+
+    // MARK - APIRequestConfig.CachePolicy
+
+    func _testCachePolicyMapping(_ cachePolicy: APIRequestConfig.CachePolicy, _ urlCachePolicy: NSURLRequest.CachePolicy) {
+        let config = APIRequestConfig(method: .get,
+                                      path: .path(""),
+                                      cachePolicy: cachePolicy)
+
+        guard let request = config.urlRequest(host: "test",
+                                              queryEncoder: APIClientSpy.encodeQuery,
+                                              bodyEncoder: APIClientSpy.encodeBody) else {
+            XCTFail("couldn't generate request from config \(config)")
+            return
+        }
+
+        XCTAssertEqual(request.cachePolicy, urlCachePolicy)
+    }
+
+    func test_request_config_with_standard_cache_policy_is_translated_to_use_protocol_cache_policy() {
+        _testCachePolicyMapping(.standard, .useProtocolCachePolicy)
+    }
+
+    func test_request_config_with_server_only_cache_policy_is_translated_to_reload_ignoring_local_and_remote_cache_data() {
+        _testCachePolicyMapping(.serverOnly, .reloadIgnoringLocalAndRemoteCacheData)
+    }
+
+    func test_request_config_with_remote_cache_or_server_cache_policy_is_translated_to_reload_ignoring_local_cache_data() {
+        _testCachePolicyMapping(.remoteCacheOrServer, .reloadIgnoringLocalCacheData)
+    }
+
+    func test_request_config_with_cache_or_server_cache_policy_is_translated_to_return_cache_data_else_load() {
+        _testCachePolicyMapping(.cacheOrServer, .returnCacheDataElseLoad)
+    }
+
+    func test_request_config_with_validated_cache_or_server_cache_policy_is_translated_to_reload_revalidating_cache_data() {
+        _testCachePolicyMapping(.validatedCacheOrServer, .reloadRevalidatingCacheData)
+    }
+
+    func test_request_config_with_cache_only_cache_policy_is_translated_to_return_cache_data_dont_load() {
+        _testCachePolicyMapping(.cacheOnly, .returnCacheDataDontLoad)
+    }
 }


### PR DESCRIPTION
We currently use the default cache policy for all requests and it is causing issues on the client side when we want to be able to ignore the URL cache.