### PR TITLE
Add array and dictionary subtype

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaSubtypeFactory.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaSubtypeFactory.swift
@@ -70,7 +70,6 @@ struct MetaSubtypeFactory {
                         .with(accessLevel: .public)
                         .adding(parameter: FunctionParameter(alias: "_", name: "identifier", type: .int).with(defaultValue: Value.int(0)))
                         .adding(members: properties.map { property in
-                            
                             let value: VariableValue
                             switch property.propertyType {
                             case .custom(let _value):
@@ -80,8 +79,17 @@ struct MetaSubtypeFactory {
                                     propertyName: property.name.camelCased().variableCased(ignoreLexicon: true),
                                     identifier: .named("identifier")
                                 )
+                            case .array(.scalar(let _value)):
+                                let itemValue: VariableValue = _value.defaultValue(
+                                    propertyName: property.name.camelCased().variableCased(ignoreLexicon: true),
+                                    identifier: .named("identifier")
+                                )
+                                value = Reference.named("[\(itemValue.swiftString)]")
+                            case .array,
+                                 .dictionary:
+                                value = .type(property.propertyType.typeID(objc: property.objc)) + .named("factoryDefaultValue")
                             }
-                            
+
                             return Assignment(
                                 variable: Reference.named(property.name.camelCased().variableCased(ignoreLexicon: true)),
                                 value: value

--- a/CodeGen/Sources/LucidCodeGenCore/Descriptions.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Descriptions.swift
@@ -289,7 +289,7 @@ public struct EndpointPayloadEntityVariation: Equatable {
 
 // MARK: - PropertyScalarType
 
-public enum PropertyScalarType: String, Equatable {
+public enum PropertyScalarType: String, Hashable {
     case string = "String"
     case int = "Int"
     case date = "Date"
@@ -614,9 +614,11 @@ public struct Subtype: Equatable {
     
     public struct Property: Equatable {
         
-        public enum PropertyType: Equatable {
+        public enum PropertyType: Hashable {
             case scalar(PropertyScalarType)
             case custom(String)
+            indirect case array(PropertyType)
+            indirect case dictionary(key: PropertyType, value: PropertyType)
         }
         
         public let name: String

--- a/CodeGen/Sources/LucidCodeGenCore/Error.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Error.swift
@@ -25,6 +25,7 @@ public enum CodeGenError: Error, CustomStringConvertible {
     case unsupportedNestedKeys
     case couldNotFindTargetEntity
     case subtypeDoesNotHaveAnyCase(String)
+    case subtypeDoesntSupportNestedArraysOrDictionaries(String)
     case cannotPersistIdentifier(String)
     case incompatiblePropertyKey(String)
     case unsupportedCaseConversion
@@ -72,6 +73,8 @@ public extension CodeGenError {
             return "At least one entity should have the property 'isTarget' set to true."
         case .subtypeDoesNotHaveAnyCase(let name):
             return "Subtype named '\(name)' does not have any case."
+        case .subtypeDoesntSupportNestedArraysOrDictionaries(let name):
+            return "Subtype named '\(name)' does not support arrays or dictionaries with nested arrays or dictionaries."
         case .cannotPersistIdentifier(let name):
             return "Cannot persist identifier in entity: '\(name)'."
         case .incompatiblePropertyKey(let key):

--- a/CodeGen/Sources/LucidCodeGenCore/MetaUtils.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/MetaUtils.swift
@@ -576,7 +576,26 @@ public extension Reference {
             .adding(parameter: TupleParameter(value: value))
         )
     }
-    
+
+    static func dictionary(key: VariableValue,
+                           ofKeyType keyTypeID: TypeIdentifier? = nil,
+                           value: VariableValue,
+                           ofValueType valueTypeID: TypeIdentifier? = nil) -> Reference {
+        let dictTypeID: TypeIdentifier
+        if let keyTypeID = keyTypeID, let valueTypeID = valueTypeID {
+            dictTypeID = .dictionary(key: keyTypeID, value: valueTypeID)
+        } else {
+            dictTypeID = TypeIdentifier(name: .dictionary)
+        }
+        return dictTypeID.reference | .call(Tuple()
+            .adding(parameter: TupleParameter(name: "dictionaryLiteral", value: Tuple()
+                .adding(parameters: [
+                    TupleParameter(value: key),
+                    TupleParameter(value: value)
+                ])
+            )))
+    }
+
     func container(keyedBy keyType: TypeIdentifier) -> Reference {
         return .try | self + .named("container") | .call(Tuple()
             .adding(parameter: TupleParameter(name: "keyedBy", value: keyType.reference + .named(.`self`)))
@@ -1096,6 +1115,10 @@ public extension Subtype.Property.PropertyType {
         case .custom(let name):
             let name = name.camelCased().suffixedName()
             return TypeIdentifier(name: objc ? "SC\(name)Objc" : name)
+        case .array(let propertyType):
+            return .array(element: propertyType.typeID(objc: objc))
+        case .dictionary(let key, let value):
+            return .dictionary(key: key.typeID(objc: objc), value: value.typeID(objc: objc))
         }
     }
 }

--- a/CodeGen/Sources/LucidCodeGenCore/StringUtils.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/StringUtils.swift
@@ -92,18 +92,38 @@ public extension String {
     var isArray: Bool {
         return hasPrefix("[") && hasSuffix("]")
     }
-    
+
+    var isDictionary: Bool {
+        return hasPrefix("{") && hasSuffix("}") && contains(":")
+    }
+
     func arrayElementType() -> String {
         guard isArray else { return self }
         var string = self
         string.removeLast()
         string.removeFirst()
-        guard string.isArray == false else {
+        guard string.isArray == false, string.isDictionary == false else {
             fatalError(CodeGenError.unsupportedType(self).description)
         }
         return string
     }
-    
+
+    func dictionaryElementTypes() -> (key: String, value: String)? {
+        guard isDictionary else { return nil }
+        var string = self
+        string.removeLast()
+        string.removeFirst()
+        let items = string.split(separator: ":").map { String($0) }
+        guard items.count == 2 else {
+            fatalError(CodeGenError.unsupportedType(self).description)
+        }
+        guard items[0].isArray == false, items[0].isDictionary == false,
+              items[1].isArray == false, items[1].isDictionary == false else {
+            fatalError(CodeGenError.unsupportedType(self).description)
+        }
+        return (key: items[0], value: items[1])
+    }
+
     var reference: Reference {
         return .named(variableCased())
     }

--- a/Lucid/Core/Color.swift
+++ b/Lucid/Core/Color.swift
@@ -22,8 +22,8 @@ private extension UIColor {
         let trimmedHex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         let hexValue = trimmedHex.replacingOccurrences(of: "#", with: "")
 
-        var rgb: Int = 0
-
+        var rgb: UInt64 = 0
+        
         var r: CGFloat = 0.0
         var g: CGFloat = 0.0
         var b: CGFloat = 0.0
@@ -33,7 +33,7 @@ private extension UIColor {
             return
         }
 
-        guard Scanner(string: hexValue).scanInt(&rgb) else {
+        guard Scanner(string: hexValue).scanHexInt64(&rgb) else {
             self.init(white: 0, alpha: 1)
             return
         }
@@ -44,9 +44,9 @@ private extension UIColor {
             g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
             b = CGFloat(rgb & 0x0000FF) / 255.0
         case .shortHex:
-            r = CGFloat((rgb & 0xF00) >> 8) / 255.0
-            g = CGFloat((rgb & 0x0F0) >> 4) / 255.0
-            b = CGFloat(rgb & 0x00F) / 255.0
+            r = CGFloat((rgb & 0xF00) >> 8) / 15.0
+            g = CGFloat((rgb & 0x0F0) >> 4) / 15.0
+            b = CGFloat(rgb & 0x00F) / 15.0
         }
 
         self.init(red: r, green: g, blue: b, alpha: 1)
@@ -55,7 +55,8 @@ private extension UIColor {
 #endif
 
 public struct Color: Equatable, Hashable {
-    let hex: String
+
+    public let hex: String
 
     public init(hex: String) {
         self.hex = hex

--- a/LucidTests/Core/DataTypeTests.swift
+++ b/LucidTests/Core/DataTypeTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @testable import Lucid
 @testable import LucidTestKit
@@ -41,7 +44,7 @@ final class DataTypeTests: XCTestCase {
         }
     }
 
-    // MARK - APIRequestConfig.CachePolicy
+    // MARK: APIRequestConfig.CachePolicy
 
     func _testCachePolicyMapping(_ cachePolicy: APIRequestConfig.CachePolicy, _ urlCachePolicy: NSURLRequest.CachePolicy) {
         let config = APIRequestConfig(method: .get,
@@ -81,4 +84,100 @@ final class DataTypeTests: XCTestCase {
     func test_request_config_with_cache_only_cache_policy_is_translated_to_return_cache_data_dont_load() {
         _testCachePolicyMapping(.cacheOnly, .returnCacheDataDontLoad)
     }
+
+    #if canImport(UIKit)
+
+    // MARK: Color
+
+    func test_red_hex_pair() {
+        let color = Color(hex: "FF0000")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 1.0)
+        XCTAssertEqual(green, 0.0)
+        XCTAssertEqual(blue, 0.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    func test_green_hex_pair() {
+        let color = Color(hex: "00FF00")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0)
+        XCTAssertEqual(green, 1.0)
+        XCTAssertEqual(blue, 0.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    func test_blue_hex_pair() {
+        let color = Color(hex: "0000FF")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0)
+        XCTAssertEqual(green, 0.0)
+        XCTAssertEqual(blue, 1.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    func test_red_short_hex() {
+        let color = Color(hex: "F00")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 1.0)
+        XCTAssertEqual(green, 0.0)
+        XCTAssertEqual(blue, 0.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    func test_green_short_hex() {
+        let color = Color(hex: "0F0")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0)
+        XCTAssertEqual(green, 1.0)
+        XCTAssertEqual(blue, 0.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    func test_blue_short_hex() {
+        let color = Color(hex: "00F")
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.colorValue.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0)
+        XCTAssertEqual(green, 0.0)
+        XCTAssertEqual(blue, 1.0)
+        XCTAssertEqual(alpha, 1.0)
+    }
+
+    #endif
 }


### PR DESCRIPTION
This commit has an update and a bug fix:

1. Adds the ability to have a `dictionary` subtype. This also formalizes `array` subtypes rather than just using string parsing.
2. Fixes a bug where Colors weren't being parsed correctly. I also added some tests.