### PR TITLE
The EndpointResultPayload and EntityGraphs should respect Lazy properties.

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaEndpointResultPayload.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaEndpointResultPayload.swift
@@ -125,6 +125,8 @@ struct MetaEndpointResultPayload {
                         \({ () -> String in
                             if entity.hasVoidIdentifier {
                                 return "    \(entity.payloadEntityAccessorVariable.name).append(value)"
+                            } else if entity.hasLazyProperties {
+                                return "    \(entity.payloadEntityAccessorVariable.name)[value.identifier] = \(entity.payloadEntityAccessorVariable.name)[value.identifier].flatMap { $0.merging(value) } ?? value"
                             } else {
                                 return "    \(entity.payloadEntityAccessorVariable.name)[value.identifier] = value"
                             }

--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityGraph.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityGraph.swift
@@ -308,7 +308,11 @@ struct MetaEntityGraph {
         case .property,
              .relationships,
              .scalarType:
-            return "\(entity.name.camelCased().variableCased().pluralName)[entity.identifier] = entity"
+            if entity.hasLazyProperties {
+                return "\(entity.name.camelCased().variableCased().pluralName)[entity.identifier] = \(entity.name.camelCased().variableCased().pluralName)[entity.identifier].flatMap { $0.merging(entity) } ?? entity"
+            } else {
+                return "\(entity.name.camelCased().variableCased().pluralName)[entity.identifier] = entity"
+            }
         }
     }
     


### PR DESCRIPTION
In some rare cases, we have payloads that contain the same data multiple times (e.g. a user object tied to a specific author in search results), but only one version of that data carries the lazy property value. In this scenario, we should make sure to merge the data cleanly.

Additionally, for performance purposes, only generate the code for entities that actually have lazy properties.

Here's an example of the generated code for two entity types, with and without lazy properties:

```swift
case .user(let entity):
    users[entity.identifier] = users[entity.identifier].flatMap { $0.merging(entity) } ?? entity
case .userCollectionDocumentsLocal(let entity):
    userCollectionDocumentsLocals[entity.identifier] = entity
```