### PR TITLE
Add support to filtered continuous observation by adding optional `insertions` and `deletions` checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       FASTLANE_LOGS: fastlane/test_output
       FASTLANE_FRAGILE_LOGS: fastlane/fragile_test_output
-      DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       FRAGILE_TESTS: LucidTests/APIClientQueueProcessorTests/test_processor_does_attempt_to_process_request_if_already_running_concurrent_request,LucidTests/CoreManagerTests/test_continuous_observer_should_receive_all_updates_in_order,LucidTests/RelationshipControllerTests/test_relationship_controller_should_continuously_send_events_when_first_event_comes_from_continuous_signal,LucidTests/RelationshipControllerTests/test_relationship_controller_should_continuously_send_events_when_first_event_comes_from_once_signal,LucidTests/StoreStackTests/test_should_fail_to_remove_in_remote_store_only_with_memory_store_first,LucidTests/RecoverableStoreTests/test_store_should_overwrite_a_non_empty_recovery_store_with_a_non_empty_main_store_at_init,LucidTests/RecoverableStoreTests/test_store_only_reflects_main_store_in_get_operations
     steps:

--- a/Lucid/Core/CoreManager.swift
+++ b/Lucid/Core/CoreManager.swift
@@ -1074,7 +1074,7 @@ private extension CoreManager {
                                 localStoresCompletion: { result in
                                     guard result?.error == nil else { return }
                                     self.raiseDeleteEvents(DualHashSet(identifiersToRemove))
-                            },
+                                },
                                 allStoresCompletion: { result in
                                     switch result {
                                     case .success, .none:
@@ -1085,7 +1085,7 @@ private extension CoreManager {
                                         Logger.log(.error, "\(CoreManager.self): An error occurred while removing entities for identifiers: \(error)")
                                         guardedPromise(.failure(.store(error)))
                                     }
-                            }
+                                }
                             )
                         }
 

--- a/Lucid/Utils/DataStructures.swift
+++ b/Lucid/Utils/DataStructures.swift
@@ -311,6 +311,22 @@ public struct DualHashDictionary<Key, Value>: Sequence where Key: DualHashable {
         }
         return values
     }
+
+    public func subtractingKeys<S>(_ otherKeys: S) -> DualHashSet<Key> where S: Sequence, S.Element == Key {
+        return subtractingKeys(DualHashSet<Key>(otherKeys))
+    }
+
+    public func subtractingKeys(_ otherKeys: DualHashSet<Key>) -> DualHashSet<Key> {
+        return DualHashSet<Key>(keys).subtracting(otherKeys)
+    }
+
+    public func intersectingKeys<S>(_ otherKeys: S) -> DualHashSet<Key> where S: Sequence, S.Element == Key {
+        return intersectingKeys(DualHashSet<Key>(otherKeys))
+    }
+
+    public func intersectingKeys(_ otherKeys: DualHashSet<Key>) -> DualHashSet<Key> {
+        return DualHashSet<Key>(keys).intersecting(otherKeys)
+    }
 }
 
 // MARK: - Set
@@ -366,6 +382,22 @@ public struct DualHashSet<Element>: Sequence where Element: DualHashable {
         for (key, _) in _values {
             _values[key] = other._values[key]
         }
+    }
+
+    public func subtracting(_ other: DualHashSet<Element>) -> DualHashSet<Element> {
+        var newSet = DualHashSet<Element>()
+        for (key, _) in _values where other._values[key] == nil {
+            newSet._values[key] = _values[key]
+        }
+        return newSet
+    }
+
+    public func intersecting(_ other: DualHashSet<Element>) -> DualHashSet<Element> {
+        var newSet = DualHashSet<Element>()
+        for (key, _) in _values {
+            newSet._values[key] = other._values[key]
+        }
+        return newSet
     }
 
     public func contains(_ element: Element) -> Bool {

--- a/LucidTests/Utils/DataStructuresTests.swift
+++ b/LucidTests/Utils/DataStructuresTests.swift
@@ -327,6 +327,43 @@ final class DualHashDictionaryTests: XCTestCase {
         otherDictionary[.remote(0, nil)] = 1
         XCTAssertNotEqual(dictionary, otherDictionary)
     }
+
+    // MARK: Subtracting Keys
+
+    func test_subtracting_keys_results_in_correct_data_set() {
+        dictionary[.remote(0, "0")] = 0
+        dictionary[.remote(1, "1")] = 1
+        dictionary[.remote(2, "2")] = 2
+        dictionary[.remote(3, "3")] = 3
+        dictionary[.remote(4, "4")] = 4
+        var other = DualHashDictionary<IdentifierValueType<String, Int>, Int>()
+        other[.remote(1, "1")] = 1
+        other[.remote(2, "2")] = 2
+        other[.remote(3, "3")] = 3
+        let subtracting = dictionary.subtractingKeys(other.keys)
+        XCTAssertTrue(subtracting.contains(.remote(0, "0")))
+        XCTAssertTrue(subtracting.contains(.remote(4, "4")))
+        XCTAssertEqual(subtracting.count, 2)
+    }
+
+    // MARK: - Intersecting Keys
+
+    func test_intersecting_keys_results_in_correct_data_set() {
+        dictionary[.remote(0, "0")] = 0
+        dictionary[.remote(1, "1")] = 1
+        dictionary[.remote(2, "2")] = 2
+        dictionary[.remote(3, "3")] = 3
+        dictionary[.remote(4, "4")] = 4
+        var other = DualHashDictionary<IdentifierValueType<String, Int>, Int>()
+        other[.remote(1, "1")] = 1
+        other[.remote(2, "2")] = 2
+        other[.remote(3, "3")] = 3
+        let intersecting = dictionary.intersectingKeys(other.keys)
+        XCTAssertTrue(intersecting.contains(.remote(1, "1")))
+        XCTAssertTrue(intersecting.contains(.remote(2, "2")))
+        XCTAssertTrue(intersecting.contains(.remote(3, "3")))
+        XCTAssertEqual(intersecting.count, 3)
+    }
 }
 
 // MARK: - Ordered Dictionaries
@@ -689,4 +726,73 @@ final class DualHashSetTests: XCTestCase {
         XCTAssertEqual(set.count, 1)
     }
 
+    // MARK: Subtract
+
+    func test_mutating_subtract_results_in_correct_data_set() {
+        set.insert(.remote(0, "0"))
+        set.insert(.remote(1, "1"))
+        set.insert(.remote(2, "2"))
+        set.insert(.remote(3, "3"))
+        set.insert(.remote(4, "4"))
+        var other = DualHashSet<IdentifierValueType<String, Int>>()
+        other.insert(.remote(1, "1"))
+        other.insert(.remote(2, "2"))
+        other.insert(.remote(3, "3"))
+        set.subtract(other)
+        XCTAssertTrue(set.contains(.remote(0, "0")))
+        XCTAssertTrue(set.contains(.remote(4, "4")))
+        XCTAssertEqual(set.count, 2)
+    }
+
+    func test_subtracting_results_in_correct_data_set() {
+        set.insert(.remote(0, "0"))
+        set.insert(.remote(1, "1"))
+        set.insert(.remote(2, "2"))
+        set.insert(.remote(3, "3"))
+        set.insert(.remote(4, "4"))
+        var other = DualHashSet<IdentifierValueType<String, Int>>()
+        other.insert(.remote(1, "1"))
+        other.insert(.remote(2, "2"))
+        other.insert(.remote(3, "3"))
+        let subtracting = set.subtracting(other)
+        XCTAssertTrue(subtracting.contains(.remote(0, "0")))
+        XCTAssertTrue(subtracting.contains(.remote(4, "4")))
+        XCTAssertEqual(subtracting.count, 2)
+    }
+
+    // MARK: Intersection
+
+    func test_mutating_intersect_results_in_correct_data_set() {
+        set.insert(.remote(0, "0"))
+        set.insert(.remote(1, "1"))
+        set.insert(.remote(2, "2"))
+        set.insert(.remote(3, "3"))
+        set.insert(.remote(4, "4"))
+        var other = DualHashSet<IdentifierValueType<String, Int>>()
+        other.insert(.remote(1, "1"))
+        other.insert(.remote(2, "2"))
+        other.insert(.remote(3, "3"))
+        set.intersection(other)
+        XCTAssertTrue(set.contains(.remote(1, "1")))
+        XCTAssertTrue(set.contains(.remote(2, "2")))
+        XCTAssertTrue(set.contains(.remote(3, "3")))
+        XCTAssertEqual(set.count, 3)
+    }
+
+    func test_intersecting_results_in_correct_data_set() {
+        set.insert(.remote(0, "0"))
+        set.insert(.remote(1, "1"))
+        set.insert(.remote(2, "2"))
+        set.insert(.remote(3, "3"))
+        set.insert(.remote(4, "4"))
+        var other = DualHashSet<IdentifierValueType<String, Int>>()
+        other.insert(.remote(1, "1"))
+        other.insert(.remote(2, "2"))
+        other.insert(.remote(3, "3"))
+        let intersecting = set.intersecting(other)
+        XCTAssertTrue(intersecting.contains(.remote(1, "1")))
+        XCTAssertTrue(intersecting.contains(.remote(2, "2")))
+        XCTAssertTrue(intersecting.contains(.remote(3, "3")))
+        XCTAssertEqual(intersecting.count, 3)
+    }
 }

--- a/LucidTests/Utils/SignalTests.swift
+++ b/LucidTests/Utils/SignalTests.swift
@@ -29,7 +29,7 @@ final class SignalTests: XCTestCase {
                 switch event {
                 case .next(let update):
                     XCTAssertEqual(update.compactMap { $0.old?.title }, ["initial_0", "initial_1", "initial_2", "initial_3", "initial_4"])
-                    XCTAssertEqual(update.map { $0.new.title }, ["new_0", "new_1", "new_2", "new_3", "new_4"])
+                    XCTAssertEqual(update.map { $0.new?.title }, ["new_0", "new_1", "new_2", "new_3", "new_4"])
                     expectation.fulfill()
 
                 case .completed:
@@ -66,7 +66,7 @@ final class SignalTests: XCTestCase {
                 switch event {
                 case .next(let update):
                     XCTAssertEqual(update.compactMap { $0.old?.title }, ["initial_0", "initial_1", "initial_2", "initial_3", "initial_4", "initial_8", "initial_9", "initial_10"])
-                    XCTAssertEqual(update.map { $0.new.title }, ["new_0", "new_1", "new_2", "new_3", "new_4", "initial_8", "initial_9", "initial_10"])
+                    XCTAssertEqual(update.map { $0.new?.title }, ["new_0", "new_1", "new_2", "new_3", "new_4", "initial_8", "initial_9", "initial_10"])
                     expectation.fulfill()
 
                 case .completed:
@@ -139,6 +139,192 @@ final class SignalTests: XCTestCase {
 
         subject.send(initialEntities)
         subject.send(newEntities)
+
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    // Insertions
+
+    func test_no_event_should_fire_for_initial_data_when_insertions_are_included() {
+        let initialEntities = (0...10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+        let newEntities =
+            (0..<5).map { EntitySpy(idValue: .remote($0, nil), title: "new_\($0)", subtitle: "new_\($0)") } +
+            (5...10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "new_\($0)") }
+
+        let subject = PassthroughSubject<[EntitySpy], Never>()
+        let expectation = self.expectation(description: "update")
+
+        subject
+            .toSignal()
+            .when(updatingOneOf: [.title], entityRules: [.insertions])
+            .observe { event in
+                switch event {
+                case .next(let update):
+                    // only the second send event triggers a response
+                    XCTAssertEqual(update.compactMap { $0.old?.title }, ["initial_0", "initial_1", "initial_2", "initial_3", "initial_4"])
+                    XCTAssertEqual(update.map { $0.new?.title }, ["new_0", "new_1", "new_2", "new_3", "new_4"])
+                    expectation.fulfill()
+
+                case .completed:
+                    XCTFail("Unexpected completed event")
+
+                case .failed:
+                    XCTFail("Unexpected failed event")
+                }
+            }
+            .dispose(in: bag)
+
+        subject.send(initialEntities)
+        subject.send(newEntities)
+
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    func test_an_event_should_fire_only_for_data_changes_when_insertions_are_not_included() {
+        let initialEntities = (0..<5).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+        let secondEntities = (0..<10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+        var thirdEntities = [EntitySpy(idValue: .remote(0, nil), title: "renamed_0", subtitle: "initial_0")]
+        thirdEntities.append(contentsOf: (1...10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") })
+
+        let subject = PassthroughSubject<[EntitySpy], Never>()
+        let expectation = self.expectation(description: "insert")
+
+        subject
+            .toSignal()
+            .when(updatingOneOf: [.title], entityRules: [])
+            .observe { event in
+                switch event {
+                case .next(let update):
+                    XCTAssertEqual(update.compactMap { $0.old?.title }, ["initial_0"])
+                    XCTAssertEqual(update.map { $0.new?.title }, ["renamed_0"])
+                    expectation.fulfill()
+    
+                case .completed:
+                    XCTFail("Unexpected completed event")
+
+                case .failed:
+                    XCTFail("Unexpected failed event")
+                }
+            }
+            .dispose(in: bag)
+
+        subject.send(initialEntities)
+        subject.send(secondEntities)
+        subject.send(thirdEntities)
+
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    // Deletions
+
+    func test_second_event_should_only_include_mutated_entities_when_deletions_are_not_included() {
+        let initialEntities = (0...10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+        let newEntities =
+            (0..<5).map { EntitySpy(idValue: .remote($0, nil), title: "new_\($0)", subtitle: "new_\($0)") } +
+            (5...8).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "new_\($0)") }
+
+        let subject = PassthroughSubject<[EntitySpy], Never>()
+        let expectation = self.expectation(description: "update")
+
+        subject
+            .toSignal()
+            .when(updatingOneOf: [.title], entityRules: [])
+            .observe { event in
+                switch event {
+                case .next(let update):
+                    XCTAssertEqual(update.compactMap { $0.old?.title }, ["initial_0", "initial_1", "initial_2", "initial_3", "initial_4"])
+                    XCTAssertEqual(update.map { $0.new?.title }, ["new_0", "new_1", "new_2", "new_3", "new_4"])
+                    expectation.fulfill()
+
+                case .completed:
+                    XCTFail("Unexpected completed event")
+
+                case .failed:
+                    XCTFail("Unexpected failed event")
+                }
+            }
+            .dispose(in: bag)
+
+        subject.send(initialEntities)
+        subject.send(newEntities)
+
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    func test_second_event_should_include_mutated_entities_and_deletions_when_deletions_are_included() {
+        let initialEntities = (0...10).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+        let newEntities =
+            (0..<5).map { EntitySpy(idValue: .remote($0, nil), title: "new_\($0)", subtitle: "new_\($0)") } +
+            (5...8).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "new_\($0)") }
+
+        let subject = PassthroughSubject<[EntitySpy], Never>()
+        let expectation = self.expectation(description: "update")
+
+        subject
+            .toSignal()
+            .when(updatingOneOf: [.title], entityRules: [.deletions])
+            .observe { event in
+                switch event {
+                case .next(let update):
+                    let oldItems = update.compactMap { $0.old?.title }
+                    // matching items will always be in order at the front of the list, but
+                    // deleted items have no guarantee of ordering
+                    XCTAssertEqual(oldItems.prefix(5), ["initial_0", "initial_1", "initial_2", "initial_3", "initial_4"])
+                    XCTAssertTrue(oldItems.contains("initial_9"))
+                    XCTAssertTrue(oldItems.contains("initial_10"))
+                    XCTAssertEqual(oldItems.count, 7)
+                    XCTAssertEqual(update.map { $0.new?.title }, ["new_0", "new_1", "new_2", "new_3", "new_4", nil, nil])
+                    expectation.fulfill()
+
+                case .completed:
+                    XCTFail("Unexpected completed event")
+
+                case .failed:
+                    XCTFail("Unexpected failed event")
+                }
+            }
+            .dispose(in: bag)
+
+        subject.send(initialEntities)
+        subject.send(newEntities)
+
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    func test_should_send_event_when_all_entities_are_deleted_when_deletions_are_included() {
+        let initialEntities = (0..<5).map { EntitySpy(idValue: .remote($0, nil), title: "initial_\($0)", subtitle: "initial_\($0)") }
+
+        let subject = PassthroughSubject<[EntitySpy], Never>()
+        let expectation = self.expectation(description: "update")
+
+        subject
+            .toSignal()
+            .when(updatingOneOf: [.title], entityRules: [.deletions])
+            .observe { event in
+                switch event {
+                case .next(let update):
+                    let oldItems = update.compactMap { $0.old?.title }
+                    // deleted items have no guarantee of ordering
+                    XCTAssertTrue(oldItems.contains("initial_0"))
+                    XCTAssertTrue(oldItems.contains("initial_1"))
+                    XCTAssertTrue(oldItems.contains("initial_2"))
+                    XCTAssertTrue(oldItems.contains("initial_3"))
+                    XCTAssertTrue(oldItems.contains("initial_4"))
+                    XCTAssertEqual(oldItems.count, 5)
+                    XCTAssertEqual(update.map { $0.new?.title }, [nil, nil, nil, nil, nil])
+                    expectation.fulfill()
+
+                case .completed:
+                    XCTFail("Unexpected completed event")
+
+                case .failed:
+                    XCTFail("Unexpected failed event")
+                }
+            }
+            .dispose(in: bag)
+
+        subject.send(initialEntities)
+        subject.send([])
 
         waitForExpectations(timeout: 0.2, handler: nil)
     }


### PR DESCRIPTION
I was investigating a bug where the reader wasn't reloading even after I deleted a restrictions object.

It was relying on this function which allows you specify a set of `indices` to observe changes for.

```swift
func when(updatingOneOf indices: [Element.Element.IndexName]?) -> SafeSignal<[(old: Element.Element?, new: Element.Element?)]>
```

However there were two concerns I had with this function:
1. Events were never sent if that object was deleted, only if it was mutated.
2. Events were always sent for inserted objects. 

So, there was some inconsistency in the behavior, and as a result the filtering in the application had a gap in the logic.

I have made the a change to the API of the above function to include an optional `entityRule` parameter to include `insertions` and `deletions`, but they are ignored by default:

```swift
public struct EntityMutationRule: OptionSet {
    public let rawValue: Int
    public init(rawValue: Int) { self.rawValue = rawValue }

    public static let insertions = EntityMutationRule(rawValue: 1 << 0)
    public static let deletions = EntityMutationRule(rawValue: 1 << 1)

    public static let dataChangesOnly: EntityMutationRule = []
    public static let all: EntityMutationRule = [.insertions, .deletions]
}

func when(updatingOneOf indices: [Element.Element.IndexName]?, entityRules: EntityMutationRule = .dataChangesOnly) -> SafeSignal<[(old: Element.Element?, new: Element.Element?)]>
```

An example usage would now be:
```swift
.when(updatingOneOf: [.accessLevel], entityRules: [.deletions])
```

And the block would only be triggered for `dataChanges` and `deletions`, but not for `insertions`.



**This PR has two commits:**

1. Update the data set functions to support this change (+ tests)
2. Updating the Signal helpers with the above changes (+ tests)