### PR TITLE
Move units tests fully to Combine

### DIFF
--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		190ADC7B2458D89C00D22F6D /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4F2458D89C00D22F6D /* BackgroundTaskManager.swift */; };
 		190ADC7C2458D89C00D22F6D /* ScheduledTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC502458D89C00D22F6D /* ScheduledTimer.swift */; };
 		190ADC7D2458D89C00D22F6D /* CancellationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC512458D89C00D22F6D /* CancellationToken.swift */; };
-		190ADC7E2458D89C00D22F6D /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal.swift */; };
+		190ADC7E2458D89C00D22F6D /* Signal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal+Extensions.swift */; };
 		190ADC7F2458D89C00D22F6D /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC532458D89C00D22F6D /* AnyEquatable.swift */; };
 		190ADCB72458D99600D22F6D /* LucidTestKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 190ADCB52458D99600D22F6D /* LucidTestKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		190ADCD12458D9A500D22F6D /* RelationshipCoreManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCBC2458D9A500D22F6D /* RelationshipCoreManagerSpy.swift */; };
@@ -99,7 +99,7 @@
 		190ADD012458DA9B00D22F6D /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC272458D89C00D22F6D /* Query.swift */; };
 		190ADD022458DA9B00D22F6D /* RemoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC422458D89C00D22F6D /* RemoteStore.swift */; };
 		190ADD032458DA9B00D22F6D /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC282458D89C00D22F6D /* Metadata.swift */; };
-		190ADD042458DA9B00D22F6D /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal.swift */; };
+		190ADD042458DA9B00D22F6D /* Signal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal+Extensions.swift */; };
 		190ADD052458DA9B00D22F6D /* CacheStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC402458D89C00D22F6D /* CacheStore.swift */; };
 		190ADD062458DA9B00D22F6D /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4D2458D89C00D22F6D /* Timestamp.swift */; };
 		190ADD072458DA9B00D22F6D /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC362458D89C00D22F6D /* Store.swift */; };
@@ -229,7 +229,7 @@
 		F48C803B2655958E00581182 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC532458D89C00D22F6D /* AnyEquatable.swift */; };
 		F48C803C2655958E00581182 /* DiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4E2458D89C00D22F6D /* DiskCache.swift */; };
 		F48C803D2655958E00581182 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC472458D89C00D22F6D /* Logger.swift */; };
-		F48C803E2655958E00581182 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal.swift */; };
+		F48C803E2655958E00581182 /* Signal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal+Extensions.swift */; };
 		F48C803F2655958E00581182 /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4D2458D89C00D22F6D /* Timestamp.swift */; };
 		F48C80402655958E00581182 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC492458D89C00D22F6D /* Result.swift */; };
 		F48C80412655958E00581182 /* CancellationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC512458D89C00D22F6D /* CancellationToken.swift */; };
@@ -274,7 +274,7 @@
 		F48C80BA2655973000581182 /* DiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4E2458D89C00D22F6D /* DiskCache.swift */; };
 		F48C80BB2655973000581182 /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4D2458D89C00D22F6D /* Timestamp.swift */; };
 		F48C80BC2655973000581182 /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4F2458D89C00D22F6D /* BackgroundTaskManager.swift */; };
-		F48C80BD2655973000581182 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal.swift */; };
+		F48C80BD2655973000581182 /* Signal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC522458D89C00D22F6D /* Signal+Extensions.swift */; };
 		F48C80BE2655973000581182 /* ReactiveKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC4A2458D89C00D22F6D /* ReactiveKit.swift */; };
 		F48C80BF2655973000581182 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC532458D89C00D22F6D /* AnyEquatable.swift */; };
 		F48C80C02655973000581182 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC492458D89C00D22F6D /* Result.swift */; };
@@ -395,7 +395,7 @@
 		190ADC4F2458D89C00D22F6D /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
 		190ADC502458D89C00D22F6D /* ScheduledTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduledTimer.swift; sourceTree = "<group>"; };
 		190ADC512458D89C00D22F6D /* CancellationToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancellationToken.swift; sourceTree = "<group>"; };
-		190ADC522458D89C00D22F6D /* Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
+		190ADC522458D89C00D22F6D /* Signal+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Signal+Extensions.swift"; sourceTree = "<group>"; };
 		190ADC532458D89C00D22F6D /* AnyEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEquatable.swift; sourceTree = "<group>"; };
 		190ADC842458D8DC00D22F6D /* LucidTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LucidTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		190ADC882458D8DC00D22F6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -914,7 +914,7 @@
 				190ADC4A2458D89C00D22F6D /* ReactiveKit.swift */,
 				190ADC492458D89C00D22F6D /* Result.swift */,
 				190ADC502458D89C00D22F6D /* ScheduledTimer.swift */,
-				190ADC522458D89C00D22F6D /* Signal.swift */,
+				190ADC522458D89C00D22F6D /* Signal+Extensions.swift */,
 				190ADC4D2458D89C00D22F6D /* Timestamp.swift */,
 			);
 			path = Utils;
@@ -2191,7 +2191,7 @@
 				190ADC552458D89C00D22F6D /* Query.swift in Sources */,
 				190ADC6F2458D89C00D22F6D /* RemoteStore.swift in Sources */,
 				190ADC562458D89C00D22F6D /* Metadata.swift in Sources */,
-				190ADC7E2458D89C00D22F6D /* Signal.swift in Sources */,
+				190ADC7E2458D89C00D22F6D /* Signal+Extensions.swift in Sources */,
 				190ADC6D2458D89C00D22F6D /* CacheStore.swift in Sources */,
 				190ADC792458D89C00D22F6D /* Timestamp.swift in Sources */,
 				190ADC642458D89C00D22F6D /* Store.swift in Sources */,
@@ -2306,7 +2306,7 @@
 				190ADD012458DA9B00D22F6D /* Query.swift in Sources */,
 				190ADD022458DA9B00D22F6D /* RemoteStore.swift in Sources */,
 				190ADD032458DA9B00D22F6D /* Metadata.swift in Sources */,
-				190ADD042458DA9B00D22F6D /* Signal.swift in Sources */,
+				190ADD042458DA9B00D22F6D /* Signal+Extensions.swift in Sources */,
 				190ADD052458DA9B00D22F6D /* CacheStore.swift in Sources */,
 				190ADD062458DA9B00D22F6D /* Timestamp.swift in Sources */,
 				190ADD072458DA9B00D22F6D /* Store.swift in Sources */,
@@ -2386,7 +2386,7 @@
 				F48C80142655958500581182 /* Color.swift in Sources */,
 				F48C80362655958E00581182 /* PropertyBox.swift in Sources */,
 				F48C803D2655958E00581182 /* Logger.swift in Sources */,
-				F48C803E2655958E00581182 /* Signal.swift in Sources */,
+				F48C803E2655958E00581182 /* Signal+Extensions.swift in Sources */,
 				F48C80272655958500581182 /* HTTPTypes.swift in Sources */,
 				F48C801C2655958500581182 /* Context.swift in Sources */,
 				F48C80292655958500581182 /* Payload.swift in Sources */,
@@ -2413,7 +2413,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F48C808E2655972700581182 /* APIClientQueueScheduling.swift in Sources */,
-				F48C80BD2655973000581182 /* Signal.swift in Sources */,
+				F48C80BD2655973000581182 /* Signal+Extensions.swift in Sources */,
 				F48C80952655972700581182 /* APIClient.swift in Sources */,
 				F48C80922655972700581182 /* RelationshipController.swift in Sources */,
 				F48C80B62655973000581182 /* AsyncOperationQueue.swift in Sources */,

--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -154,7 +154,7 @@
 		1987F9F02554A4C00057F1CC /* DataStructuresTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ED00942481C3960033B7BD /* DataStructuresTests.swift */; };
 		1987F9F62554A4D70057F1CC /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC9F2458D8FE00D22F6D /* DiskCacheTests.swift */; };
 		1987F9FC2554A4E50057F1CC /* DiskQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC9D2458D8FE00D22F6D /* DiskQueueTests.swift */; };
-		1987FA022554A4F50057F1CC /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC9E2458D8FE00D22F6D /* SignalTests.swift */; };
+		1987FA022554A4F50057F1CC /* PublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC9E2458D8FE00D22F6D /* PublisherTests.swift */; };
 		1987FA082554A50F0057F1CC /* BaseStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC962458D8FE00D22F6D /* BaseStoreTests.swift */; };
 		1987FA0E2554A5150057F1CC /* CacheStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC922458D8FE00D22F6D /* CacheStoreTests.swift */; };
 		1987FA142554A5230057F1CC /* CoreDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC942458D8FE00D22F6D /* CoreDataStoreTests.swift */; };
@@ -415,7 +415,7 @@
 		190ADC9A2458D8FE00D22F6D /* StoreStackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreStackTests.swift; sourceTree = "<group>"; };
 		190ADC9B2458D8FE00D22F6D /* CoreManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreManagerTests.swift; sourceTree = "<group>"; };
 		190ADC9D2458D8FE00D22F6D /* DiskQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskQueueTests.swift; sourceTree = "<group>"; };
-		190ADC9E2458D8FE00D22F6D /* SignalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalTests.swift; sourceTree = "<group>"; };
+		190ADC9E2458D8FE00D22F6D /* PublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublisherTests.swift; sourceTree = "<group>"; };
 		190ADC9F2458D8FE00D22F6D /* DiskCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
 		190ADCB32458D99600D22F6D /* LucidTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LucidTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		190ADCB52458D99600D22F6D /* LucidTestKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LucidTestKit.h; sourceTree = "<group>"; };
@@ -977,7 +977,7 @@
 				19ED00942481C3960033B7BD /* DataStructuresTests.swift */,
 				190ADC9F2458D8FE00D22F6D /* DiskCacheTests.swift */,
 				190ADC9D2458D8FE00D22F6D /* DiskQueueTests.swift */,
-				190ADC9E2458D8FE00D22F6D /* SignalTests.swift */,
+				190ADC9E2458D8FE00D22F6D /* PublisherTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2245,7 +2245,7 @@
 				1987FA642555DD410057F1CC /* APIClientQueueTests.swift in Sources */,
 				1987FA142554A5230057F1CC /* CoreDataStoreTests.swift in Sources */,
 				1987FA382554A5740057F1CC /* StoreStackTests.swift in Sources */,
-				1987FA022554A4F50057F1CC /* SignalTests.swift in Sources */,
+				1987FA022554A4F50057F1CC /* PublisherTests.swift in Sources */,
 				1987FA3E2554A5810057F1CC /* RelationshipControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2616,7 +2616,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LUCID_REACTIVE_KIT = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scribd.iscribd.LucidTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -2918,7 +2917,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				LUCID_REACTIVE_KIT = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scribd.iscribd.LucidTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -184,6 +184,10 @@
 		DEA5C25226AA1D77002FEADD /* ReactiveKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEA5C24626AA1C2B002FEADD /* ReactiveKit.xcframework */; };
 		DEA5C25526AA20D3002FEADD /* ReactiveKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEA5C24626AA1C2B002FEADD /* ReactiveKit.xcframework */; };
 		F41D210724EF041E009444A2 /* Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45FA8FA24EC8D3C00368CCB /* Contract.swift */; };
+		F440173827A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
+		F440173927A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
+		F440173A27A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
+		F440173B27A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
 		F45FA8FB24EC8D3C00368CCB /* Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45FA8FA24EC8D3C00368CCB /* Contract.swift */; };
 		F47E5EFB24AA57BC007DCC4A /* StubCoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F47E5EF924AA57BC007DCC4A /* StubCoreDataModel.xcdatamodeld */; };
 		F487D3982684702A00AB701B /* BackgroundTaskManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCBE2458D9A500D22F6D /* BackgroundTaskManagerSpy.swift */; };
@@ -744,6 +748,7 @@
 		F405C35024A41844004E1BB3 /* APIClientQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueTests.swift; sourceTree = "<group>"; };
 		F405C35124A41844004E1BB3 /* APIClientQueueDefaultSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueDefaultSchedulerTests.swift; sourceTree = "<group>"; };
 		F405C35224A41844004E1BB3 /* APIClientQueueProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueProcessorTests.swift; sourceTree = "<group>"; };
+		F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
 		F45FA8FA24EC8D3C00368CCB /* Contract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contract.swift; sourceTree = "<group>"; };
 		F47E5EFA24AA57BC007DCC4A /* StubCoreDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = StubCoreDataModel.xcdatamodel; sourceTree = "<group>"; };
 		F48C717624896F5400099980 /* CoreManagerContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreManagerContractTests.swift; sourceTree = "<group>"; };
@@ -911,6 +916,7 @@
 				190ADC4C2458D89C00D22F6D /* DiskQueue.swift */,
 				190ADC472458D89C00D22F6D /* Logger.swift */,
 				190ADC482458D89C00D22F6D /* PropertyBox.swift */,
+				F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */,
 				190ADC4A2458D89C00D22F6D /* ReactiveKit.swift */,
 				190ADC492458D89C00D22F6D /* Result.swift */,
 				190ADC502458D89C00D22F6D /* ScheduledTimer.swift */,
@@ -2182,6 +2188,7 @@
 				190ADC762458D89C00D22F6D /* ReactiveKit.swift in Sources */,
 				190ADC752458D89C00D22F6D /* Result.swift in Sources */,
 				190ADC5B2458D89C00D22F6D /* APIClient.swift in Sources */,
+				F440173927A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */,
 				190ADC592458D89C00D22F6D /* Entity.swift in Sources */,
 				F45FA8FB24EC8D3C00368CCB /* Contract.swift in Sources */,
 				1907AD8424A682D300727F82 /* Configuration.swift in Sources */,
@@ -2297,6 +2304,7 @@
 				190ADCFA2458DA9B00D22F6D /* ReactiveKit.swift in Sources */,
 				190ADCFB2458DA9B00D22F6D /* Result.swift in Sources */,
 				190ADCFC2458DA9B00D22F6D /* APIClient.swift in Sources */,
+				F440173B27A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */,
 				190ADCFD2458DA9B00D22F6D /* Entity.swift in Sources */,
 				F41D210724EF041E009444A2 /* Contract.swift in Sources */,
 				1907AD8624A682DB00727F82 /* Configuration.swift in Sources */,
@@ -2379,6 +2387,7 @@
 				F48C801E2655958500581182 /* Query.swift in Sources */,
 				F48C80262655958500581182 /* EntityIndexValue.swift in Sources */,
 				F48C802F2655958A00581182 /* RemoteStore.swift in Sources */,
+				F440173827A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */,
 				F48C80242655958500581182 /* APIClientQueueScheduling.swift in Sources */,
 				F48C80192655958500581182 /* Entity+Query.swift in Sources */,
 				F48C80382655958E00581182 /* AsyncOperationQueue.swift in Sources */,
@@ -2432,6 +2441,7 @@
 				F48C80B42655973000581182 /* PropertyBox.swift in Sources */,
 				F48C80972655972700581182 /* Time.swift in Sources */,
 				F48C80902655972700581182 /* APIRequestDeduplicator.swift in Sources */,
+				F440173A27A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */,
 				F48C80B82655973000581182 /* DiskQueue.swift in Sources */,
 				F48C80A82655972B00581182 /* RemoteStore.swift in Sources */,
 				F48C80B32655973000581182 /* AnySequence.swift in Sources */,

--- a/Lucid/Core/APIClientQueue.swift
+++ b/Lucid/Core/APIClientQueue.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ReactiveKit
 
 #if canImport(UIKit)
 import UIKit
@@ -487,7 +486,6 @@ final class APIClientQueueProcessor {
 
     #if canImport(UIKit) && os(iOS)
     private let _backgroundTaskManager: BackgroundTaskManaging
-    private let backgroundTaskID = Property<UIBackgroundTaskIdentifier>(.invalid)
     #endif
 
     weak var delegate: APIClientQueueProcessorDelegate? {

--- a/Lucid/Core/Context.swift
+++ b/Lucid/Core/Context.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ReactiveKit
 
 #if !LUCID_REACTIVE_KIT
 import Combine

--- a/Lucid/Core/Entity.swift
+++ b/Lucid/Core/Entity.swift
@@ -447,7 +447,7 @@ public enum RemotePath<E>: Equatable where E: RemoteEntity {
     case remove(E.Identifier)
     case removeAll(Query<E>)
 
-    public func identifier<ID>() -> ID? where ID: RemoteIdentifier, ID == E.Identifier {
+    public func identifier<ID>() -> ID? where ID == E.Identifier {
         switch self {
         case .get(let identifier),
              .remove(let identifier):

--- a/Lucid/Core/RelationshipController.swift
+++ b/Lucid/Core/RelationshipController.swift
@@ -520,7 +520,6 @@ public extension RelationshipController {
                     },
                 rootEntities
                     .continuous
-                    .mapError { _ in ManagerError.notSupported }
                     .receive(on: dispatchQueue)
                     .flatMapLatest { entities -> Signal<Graph, ManagerError> in
                         defer { eventCount += 1 }

--- a/Lucid/Utils/BackgroundTaskManager.swift
+++ b/Lucid/Utils/BackgroundTaskManager.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ReactiveKit
 
 #if canImport(UIKit) && os(iOS)
 import UIKit

--- a/Lucid/Utils/Publisher+Extensions.swift
+++ b/Lucid/Utils/Publisher+Extensions.swift
@@ -1,0 +1,340 @@
+//
+//  Publisher+Extensions.swift
+//  Lucid
+//
+//  Created by Stephane Magne on 1/28/22.
+//  Copyright © 2022 Scribd. All rights reserved.
+//
+
+#if !LUCID_REACTIVE_KIT
+import Combine
+
+// MARK: - Typealiases
+
+public typealias SafePublisher<Output> = AnyPublisher<Output, Never>
+
+// MARK: - Flat Map Errors
+
+public extension Publisher {
+
+    /// Transform an error into a result with a new error type. This allows the call-site to transform an error into successful output, or into a new error value.
+    /// - Note: The original Publisher will still be completed, so this can only be used on 'once' signals.
+    func flatMapError<F>(_ transform: @escaping (Failure) -> Result<Output, F>) -> AnyPublisher<Output, F> where F: Error {
+        return ErrorTransformSubject<Output, Failure, F>(observing: eraseToAnyPublisher(), transform: transform).eraseToAnyPublisher()
+    }
+
+    /// Transform an error into a new error type.
+    /// - Note: The original Publisher will still be completed, so this can only be used on 'once' signals.
+    func flatMapError<F>(_ transform: @escaping (Failure) -> F) -> AnyPublisher<Output, F> where F: Error {
+        return flatMapError { error -> Result<Output, F> in
+            return .failure(transform(error))
+        }
+    }
+
+    /// Transform an error into successful output.
+    /// - Note: The original Publisher will still be completed, so this can only be used on 'once' signals.
+    func flatMapError(_ transform: @escaping (Failure) -> Output) -> AnyPublisher<Output, Failure> {
+        return flatMapError { error -> Result<Output, Failure> in
+            return .success(transform(error))
+        }
+    }
+}
+
+// MARK: - Error Substitutions
+
+public extension AnyPublisher where Failure == ManagerError {
+
+    func substituteValueForNonCriticalFailure(_ value: Output) -> AnyPublisher<Output, ManagerError> {
+        return self
+            .substituteValueForInternetConnectionFailure(value)
+            .substituteValueForUserAccessFailure(value)
+    }
+
+    func substituteValueForInternetConnectionFailure(_ value: Output) -> AnyPublisher<Output, ManagerError> {
+
+        return flatMapError { managerError -> Result<Output, ManagerError> in
+            if managerError.isNetworkConnectionFailure {
+                return .success(value)
+            } else {
+                return .failure(managerError)
+            }
+        }
+    }
+
+    func substituteValueForUserAccessFailure(_ value: Output) -> AnyPublisher<Output, ManagerError> {
+        return flatMapError { managerError -> Result<Output, ManagerError> in
+            if managerError.isUserAccessFailure {
+                return .success(value)
+            } else {
+                return .failure(managerError)
+            }
+        }
+    }
+}
+
+// MARK: - Mutation Filtering
+
+public struct EntityMutationRule: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+
+    public static let insertions = EntityMutationRule(rawValue: 1 << 0)
+    public static let deletions = EntityMutationRule(rawValue: 1 << 1)
+
+    public static let dataChangesOnly: EntityMutationRule = []
+    public static let all: EntityMutationRule = [.insertions, .deletions]
+}
+
+public extension Publisher where Output: Sequence, Output.Element: Entity, Failure == Never {
+
+    var whenUpdatingAnything: SafePublisher<[(old: Output.Element?, new: Output.Element?)]> {
+        return when(updatingOneOf: nil, entityRules: .all)
+    }
+
+    func when(updatingOneOf indices: [Output.Element.IndexName]?, entityRules: EntityMutationRule = .dataChangesOnly) -> SafePublisher<[(old: Output.Element?, new: Output.Element?)]> {
+        var _lastElements: DualHashDictionary<Output.Element.Identifier, Output.Element>?
+        let dispatchQueue = DispatchQueue(label: "\(Self.self):updates")
+
+        return receive(on: dispatchQueue).compactMap { elements -> [(old: Output.Element?, new: Output.Element?)]? in
+            defer { _lastElements = DualHashDictionary(elements.lazy.map { ($0.identifier, $0) }) }
+            guard let lastElements = _lastElements else { return nil }
+
+            var update: [(old: Output.Element?, new: Output.Element?)] = elements.compactMap { element in
+                guard let lastElement = lastElements[element.identifier] else {
+                    if entityRules.contains(.insertions) {
+                        return (nil, element)
+                    } else {
+                        return nil
+                    }
+                }
+
+                let shouldUpdate = indices?.contains { index in
+                    element.entityIndexValue(for: index) != lastElement.entityIndexValue(for: index)
+                } ?? true
+
+                return shouldUpdate ? (lastElement, element) : nil
+            }
+
+            if entityRules.contains(.deletions) {
+                let deletedIndices = lastElements.subtractingKeys(elements.lazy.map { $0.identifier }.compactMap { $0})
+                update.append(contentsOf: deletedIndices.map { (old: lastElements[$0], new: nil) })
+            }
+
+            return update.isEmpty ? nil : update
+        }.eraseToAnyPublisher()
+    }
+}
+
+public extension Publisher where Output: Entity, Failure == Never {
+
+    var whenUpdatingAnything: SafePublisher<(old: Output?, new: Output?)> {
+        return when(updatingOneOf: nil, entityRules: .all)
+    }
+
+    func when(updatingOneOf indices: [Output.IndexName]?, entityRules: EntityMutationRule = .dataChangesOnly) -> SafePublisher<(old: Output?, new: Output?)> {
+        return map { [$0] }.when(updatingOneOf: indices, entityRules: entityRules).compactMap { $0.first }.eraseToAnyPublisher()
+    }
+}
+
+public extension Publisher where Output: OptionalProtocol, Output.Wrapped: Entity, Failure == Never {
+
+    var whenUpdatingAnything: SafePublisher<(old: Output.Wrapped?, new: Output.Wrapped?)> {
+        return when(updatingOneOf: nil, entityRules: .all)
+    }
+
+    func when(updatingOneOf indices: [Output.Wrapped.IndexName]?, entityRules: EntityMutationRule = .dataChangesOnly) -> SafePublisher<(old: Output.Wrapped?, new: Output.Wrapped?)> {
+        return map { $0._unbox.flatMap { [$0] } ?? [] }.when(updatingOneOf: indices, entityRules: entityRules).compactMap { $0.first }.eraseToAnyPublisher()
+    }
+}
+
+// MARK: - OptionalProtocol
+
+public protocol OptionalProtocol {
+    associatedtype Wrapped
+    var _unbox: Optional<Wrapped> { get }
+    init(nilLiteral: ())
+    init(_ some: Wrapped)
+}
+
+extension Optional: OptionalProtocol {
+
+    public var _unbox: Optional<Wrapped> {
+        return self
+    }
+}
+
+// MARK: - Error Helpers
+
+public extension ManagerError {
+
+    var isNetworkConnectionFailure: Bool {
+
+        switch self {
+        case .notSupported,
+             .conflict,
+             .logicalError,
+             .userAccessInvalid:
+            return false
+        case .store(let storeError):
+            return storeError.isNetworkConnectionFailure
+        }
+    }
+
+    var isUserAccessFailure: Bool {
+
+        switch self {
+        case .notSupported,
+             .conflict,
+             .logicalError,
+             .store:
+            return false
+        case .userAccessInvalid:
+            return true
+        }
+    }
+
+    var shouldFallBackToLocalStore: Bool {
+        switch self {
+        case .notSupported,
+             .conflict,
+             .logicalError,
+             .userAccessInvalid:
+            return false
+        case .store(let storeError):
+            return storeError.shouldFallBackToLocalStore
+        }
+    }
+}
+
+public extension StoreError {
+
+    var isNetworkConnectionFailure: Bool {
+        switch self {
+        case .api(let apiError):
+            return apiError.isNetworkConnectionFailure
+        case .composite,
+             .unknown,
+             .notSupported,
+             .notFoundInPayload,
+             .emptyStack,
+             .invalidCoreDataState,
+             .invalidCoreDataEntity,
+             .coreData,
+             .invalidContext,
+             .identifierNotSynced,
+             .identifierNotFound,
+             .emptyResponse:
+            return false
+        }
+    }
+
+    var isEmptyResponse: Bool {
+        switch self {
+        case .emptyResponse:
+            return true
+        case .api,
+             .composite,
+             .unknown,
+             .notSupported,
+             .notFoundInPayload,
+             .emptyStack,
+             .invalidCoreDataState,
+             .invalidCoreDataEntity,
+             .coreData,
+             .invalidContext,
+             .identifierNotSynced,
+             .identifierNotFound:
+            return false
+        }
+    }
+
+    var shouldFallBackToLocalStore: Bool {
+        return isNetworkConnectionFailure || isEmptyResponse
+    }
+}
+
+public extension APIError {
+
+    var isNetworkConnectionFailure: Bool {
+        switch self {
+        case .network(.networkConnectionFailure):
+            return true
+        case .api,
+             .deserialization,
+             .network,
+             .networkingProtocolIsNotHTTP,
+             .url,
+             .other:
+            return false
+        }
+    }
+}
+
+extension Array: Error where Element: Error {}
+
+// MARK: - ErrorTransformSubject
+
+private final class ErrorTransformSubject<Output, OriginalFailure, Failure>: Publisher where OriginalFailure: Error, Failure: Error {
+
+    private var publisher: AnyPublisher<Output, OriginalFailure>?
+
+    private var transform: ((OriginalFailure) -> Result<Output, Failure>)?
+
+    public init(observing publisher: AnyPublisher<Output, OriginalFailure>, transform: @escaping (OriginalFailure) -> Result<Output, Failure>) {
+        self.publisher = publisher
+        self.transform = transform
+    }
+
+    func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+        guard let publisher = publisher, let transform = transform else { return }
+
+        let cancellable = publisher
+            .sink(receiveCompletion: { error in
+                switch error {
+                case .failure(let originalError):
+                    let transformedError = transform(originalError)
+                    switch transformedError {
+                    case .success(let value):
+                        _ = subscriber.receive(value)
+                    case .failure(let errorValue):
+                        subscriber.receive(completion: .failure(errorValue))
+                    }
+                case .finished:
+                    subscriber.receive(completion: .finished)
+                }
+            }, receiveValue: { value in
+                  _ = subscriber.receive(value)
+            })
+
+        let subscription = ErrorTransformSubject(subscriber, cancellable)
+        subscriber.receive(subscription: subscription)
+
+        self.publisher = nil
+        self.transform = nil
+    }
+}
+
+// MARK: - Subscription
+
+private extension ErrorTransformSubject {
+
+    final class ErrorTransformSubject<S: Subscriber>: Subscription where S.Input == Output, S.Failure == Failure {
+
+        private var subscriber: S?
+
+        private var cancellable: Cancellable?
+
+        init(_ subscriber: S, _ cancellable: Cancellable) {
+            self.subscriber = subscriber
+            self.cancellable = cancellable
+        }
+
+        func cancel() {
+            cancellable = nil
+            subscriber = nil
+        }
+
+        func request(_ demand: Subscribers.Demand) { }
+    }
+}
+#endif

--- a/Lucid/Utils/Signal+Extensions.swift
+++ b/Lucid/Utils/Signal+Extensions.swift
@@ -1,11 +1,12 @@
 //
-//  Signal.swift
+//  Signal+Extensions.swift
 //  Lucid
 //
 //  Created by Théophane Rupin on 8/19/19.
 //  Copyright © 2019 Scribd. All rights reserved.
 //
 
+#if LUCID_REACTIVE_KIT
 import ReactiveKit
 import Foundation
 
@@ -223,3 +224,4 @@ public extension APIError {
 }
 
 extension Array: Error where Element: Error {}
+#endif

--- a/LucidTests/Utils/BackgroundTaskManagerTests.swift
+++ b/LucidTests/Utils/BackgroundTaskManagerTests.swift
@@ -10,7 +10,6 @@
 import LucidTestKit
 
 import XCTest
-import ReactiveKit
 
 final class BackgroundTaskManagerTests: XCTestCase {
 

--- a/LucidTests/Utils/SignalTests.swift
+++ b/LucidTests/Utils/SignalTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Scribd. All rights reserved.
 //
 
+#if LUCID_REACTIVE_KIT
 @testable import Lucid
 @testable import LucidTestKit
 import XCTest
@@ -329,3 +330,4 @@ final class SignalTests: XCTestCase {
         waitForExpectations(timeout: 0.2, handler: nil)
     }
 }
+#endif


### PR DESCRIPTION
This PR makes a few key changes to the Lucid project:

1. It removes ReactiveKit imports wherever possible and adds `#if` around any exposed ReactiveKit code.
2. It adds a new file `Publisher+extensions` to give Combine.Publisher the same custom extension as `ReactiveKit.Signal`.
3. It adds an extension for `Combine.Publisher` to add three `flatMapError` functions. This is functionality that we use in a few places in both iScribd and Lucid, so this will give us the ability to transpose logic. (There is also a private class added to support this, `ErrorTransformSubject`. Tests are added later to verify the flatMapError functions).
4. Removes the ReactiveKit requirement for the Lucid tests and ports the Signal tests to Publisher tests.

**Note:** This will make the exposed API 100% Combine and will allow us to import Lucid via SwiftPM. However, some of the underlying classes still use ReactiveKit to post data (this is how we can support both versions of the framework). We can fully deprecate ReactiveKit under the hood at a later date and make sure all tests pass before brining that into iScribd. This two-stage pass will guarantee us more stability in the short term.