### PR TITLE
Update Lucid CodeGen to move cached files to `~/Library`. 

### DIFF
--- a/CodeGen/Sources/LucidCommand/CommandConfiguration.swift
+++ b/CodeGen/Sources/LucidCommand/CommandConfiguration.swift
@@ -255,7 +255,7 @@ private enum Defaults {
     static let configPath = Path(".lucid.yaml")
     static let organizationName = "MyOrganization"
     static let currentVersion = "1.0.0"
-    static let cachePath = Path("/usr/local/share/lucid/cache")
+    static let cachePath = Path("~/Library/Caches/Lucid").absolute()
     static let gitRemote: String? = nil
     static let forceBuildNewDBModel = true
     static let forceBuildNewDBModelForVersions = Set<String>()

--- a/CodeGen/Sources/LucidCommand/DescriptionsVersionManager.swift
+++ b/CodeGen/Sources/LucidCommand/DescriptionsVersionManager.swift
@@ -62,6 +62,12 @@ final class DescriptionsVersionManager {
             try logger.throwError("Input path needs to be a relative path.")
         }
 
+        if repositoryPath.exists == false {
+            logger.info("Initialzing git repo for cached repository. The project fetch could take a while, this would be a good time to take a break.")
+            try repositoryPath.mkpath()
+            try shellOut(to: "git init --quiet", at: repositoryPath.absolute().string)
+        }
+
         if let gitRemote = gitRemote {
             try shellOut(to: "git remote remove origin || true", at: repositoryPath.absolute().string)
             try shellOut(to: "git remote add origin \(gitRemote)", at: repositoryPath.absolute().string)
@@ -82,7 +88,7 @@ final class DescriptionsVersionManager {
         try cacheRepository()
 
         try shellOut(to: "git fetch origin tag \(releaseTag) --no-tags --quiet", at: repositoryPath.absolute().string)
-        try shellOut(to: "git reset --hard --quiet \(releaseTag) --", at: repositoryPath.absolute().string)
+        try shellOut(to: "git add -A && git reset --hard --quiet \(releaseTag) --", at: repositoryPath.absolute().string)
         logger.done("Checked out \(releaseTag).")
 
         if destinationDescriptionsPath.exists {


### PR DESCRIPTION
This also fixes issues with zsh.