### PR TITLE
Add a series of Combine helpers

### DIFF
--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		F48C80BF2655973000581182 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC532458D89C00D22F6D /* AnyEquatable.swift */; };
 		F48C80C02655973000581182 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC492458D89C00D22F6D /* Result.swift */; };
 		F48C80C12655973000581182 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC472458D89C00D22F6D /* Logger.swift */; };
+		F4EF380727ADCCF000964191 /* PayloadPersistenceManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -755,6 +756,7 @@
 		F48C7FFA2655948200581182 /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F48C8058265596D700581182 /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4A40EBF2513B8700025E48C /* CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodingPathTests.swift; sourceTree = "<group>"; };
+		F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadPersistenceManagerSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1014,6 +1016,7 @@
 				190ADCCA2458D9A500D22F6D /* FakeStore.swift */,
 				190ADCC12458D9A500D22F6D /* GraphStub.swift */,
 				190ADCC42458D9A500D22F6D /* LoggerMock.swift */,
+				F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */,
 				190ADCBC2458D9A500D22F6D /* RelationshipCoreManagerSpy.swift */,
 				190ADCC32458D9A500D22F6D /* StoreSpy.swift */,
 				190ADCBD2458D9A500D22F6D /* StubCoreDataManagerFactory.swift */,
@@ -2257,6 +2260,7 @@
 				190ADCD22458D9A500D22F6D /* StubCoreDataManagerFactory.swift in Sources */,
 				190ADCD42458D9A500D22F6D /* EntityRelationshipSpy.swift in Sources */,
 				190ADCE12458D9A500D22F6D /* DiskCacheSpy.swift in Sources */,
+				F4EF380727ADCCF000964191 /* PayloadPersistenceManagerSpy.swift in Sources */,
 				190ADCDB2458D9A500D22F6D /* CoreManagerSpy.swift in Sources */,
 				190ADCDD2458D9A500D22F6D /* UserAccessValidatorSpy.swift in Sources */,
 				190ADCD92458D9A500D22F6D /* LoggerMock.swift in Sources */,

--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -284,6 +284,10 @@
 		F48C80C02655973000581182 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC492458D89C00D22F6D /* Result.swift */; };
 		F48C80C12655973000581182 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC472458D89C00D22F6D /* Logger.swift */; };
 		F4EF380727ADCCF000964191 /* PayloadPersistenceManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */; };
+		F4FEEF9A27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
+		F4FEEF9B27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
+		F4FEEF9C27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
+		F4FEEF9D27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -757,6 +761,7 @@
 		F48C8058265596D700581182 /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4A40EBF2513B8700025E48C /* CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodingPathTests.swift; sourceTree = "<group>"; };
 		F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadPersistenceManagerSpy.swift; sourceTree = "<group>"; };
+		F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -919,6 +924,7 @@
 				190ADC472458D89C00D22F6D /* Logger.swift */,
 				190ADC482458D89C00D22F6D /* PropertyBox.swift */,
 				F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */,
+				F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */,
 				190ADC4A2458D89C00D22F6D /* ReactiveKit.swift */,
 				190ADC492458D89C00D22F6D /* Result.swift */,
 				190ADC502458D89C00D22F6D /* ScheduledTimer.swift */,
@@ -2173,6 +2179,7 @@
 			files = (
 				190ADC6C2458D89C00D22F6D /* LRUStore.swift in Sources */,
 				190ADC5F2458D89C00D22F6D /* ManagerResult.swift in Sources */,
+				F4FEEF9B27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */,
 				190ADC702458D89C00D22F6D /* InMemoryStore.swift in Sources */,
 				190ADC662458D89C00D22F6D /* Payload.swift in Sources */,
 				190ADC6A2458D89C00D22F6D /* EntityIndexValue.swift in Sources */,
@@ -2290,6 +2297,7 @@
 			files = (
 				190ADCE92458DA9B00D22F6D /* LRUStore.swift in Sources */,
 				190ADCEA2458DA9B00D22F6D /* ManagerResult.swift in Sources */,
+				F4FEEF9D27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */,
 				190ADCEB2458DA9B00D22F6D /* InMemoryStore.swift in Sources */,
 				190ADCEC2458DA9B00D22F6D /* Payload.swift in Sources */,
 				190ADCED2458DA9B00D22F6D /* EntityIndexValue.swift in Sources */,
@@ -2373,6 +2381,7 @@
 			files = (
 				F48C80322655958A00581182 /* CacheStore.swift in Sources */,
 				F48C801F2655958500581182 /* CoreManager.swift in Sources */,
+				F4FEEF9A27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */,
 				F48C80152655958500581182 /* Entity.swift in Sources */,
 				F48C80372655958E00581182 /* ReactiveKit.swift in Sources */,
 				F48C80302655958A00581182 /* InMemoryStore.swift in Sources */,
@@ -2427,6 +2436,7 @@
 			files = (
 				F48C808E2655972700581182 /* APIClientQueueScheduling.swift in Sources */,
 				F48C80BD2655973000581182 /* Signal+Extensions.swift in Sources */,
+				F4FEEF9C27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */,
 				F48C80952655972700581182 /* APIClient.swift in Sources */,
 				F48C80922655972700581182 /* RelationshipController.swift in Sources */,
 				F48C80B62655973000581182 /* AsyncOperationQueue.swift in Sources */,

--- a/Lucid/Utils/Publisher+Extensions.swift
+++ b/Lucid/Utils/Publisher+Extensions.swift
@@ -41,6 +41,21 @@ public extension Publisher {
     }
 }
 
+// MARK: - Map To Result
+
+public extension Publisher {
+
+    func mapToResult() -> AnySafePublisher<Result<Output, Failure>> {
+        return map { output -> Result<Output, Failure> in
+            return .success(output)
+        }
+        .flatMapError { error -> Result<Result<Output, Failure>, Never> in
+            return .success(.failure(error))
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
 // MARK: - Error Substitutions
 
 public extension AnyPublisher where Failure == ManagerError {

--- a/Lucid/Utils/Publisher+Extensions.swift
+++ b/Lucid/Utils/Publisher+Extensions.swift
@@ -83,7 +83,7 @@ extension Publisher where Output: OptionalProtocol {
 
 // MARK: - Error Substitutions
 
-public extension AnyPublisher where Failure == ManagerError {
+public extension Publisher where Failure == ManagerError {
 
     func substituteValueForNonCriticalFailure(_ value: Output) -> AnyPublisher<Output, ManagerError> {
         return self

--- a/Lucid/Utils/Publishers+Extensions.swift
+++ b/Lucid/Utils/Publishers+Extensions.swift
@@ -1,0 +1,121 @@
+//
+//  Publishers+Extensions.swift
+//  Lucid
+//
+//  Created by Stephane Magne on 3/09/22.
+//  Copyright © 2022 Scribd. All rights reserved.
+//
+
+#if !LUCID_REACTIVE_KIT
+import Combine
+import Foundation
+
+// MARK: - AMB
+
+public extension Publishers {
+
+    struct AMB<Output, Failure: Error>: Publisher {
+
+        private var future: Future<Output, Failure>?
+
+        private let publishers: [AnyPublisher<Output, Failure>]
+
+        private let allowAllToFinish: Bool
+
+        private let queue: DispatchQueue
+
+        init<P>(_ publishers: [P], allowAllToFinish: Bool = true, queue: DispatchQueue = DispatchQueue(label: "amb_queue")) where P: Publisher, P.Output == Output, P.Failure == Failure {
+            self.publishers = publishers.map { ($0 as? AnyPublisher<Output, Failure>) ?? $0.eraseToAnyPublisher() }
+            self.allowAllToFinish = allowAllToFinish
+            self.queue = queue
+        }
+
+        public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+
+            let subscription = AMBSubscription(self, subscriber, count: publishers.count)
+
+            let cancellable = Future<Output, Failure> { promise in
+
+                var hasBeenChosen: Bool = false
+
+                let attemptChoice: (Result<Output, Failure>, @escaping () -> Void) -> Void = { result, completion in
+                    self.queue.async(flags: .barrier) {
+                        defer { completion() }
+                        if hasBeenChosen {
+                            return
+                        }
+                        hasBeenChosen = true
+                        promise(result)
+                    }
+                }
+
+                self.queue.sync {
+
+                    self.publishers.enumerated().forEach { index, publisher in
+
+                        let completion = {
+                            if self.allowAllToFinish {
+                                subscription.cancellableSets[index].forEach { $0.cancel() }
+                            } else {
+                                subscription.cancellableSets.forEach { $0.forEach { $0.cancel() } }
+                            }
+                        }
+
+                        publisher
+                            .sink(receiveCompletion: { terminal in
+                                switch terminal {
+                                case .failure(let error):
+                                    attemptChoice(.failure(error), completion)
+                                case .finished:
+                                    subscription.cancellableSets[index].forEach { $0.cancel() }
+                                }
+                            }, receiveValue: { value in
+                                attemptChoice(.success(value), completion)
+                            })
+                            .store(in: &subscription.cancellableSets[index])
+                    }
+                }
+            }
+            .sink(receiveCompletion: { terminal in
+                subscriber.receive(completion: terminal)
+            }, receiveValue: { value in
+                _ = subscriber.receive(value)
+            })
+
+            subscription.cancellable = cancellable
+            subscriber.receive(subscription: subscription)
+        }
+    }
+}
+// MARK: - Subscription
+
+private extension Publishers.AMB {
+
+    final class AMBSubscription<S: Subscriber>: Subscription where S.Input == Output, S.Failure == Failure {
+
+        private var reference: Any?
+
+        private var subscriber: S?
+
+        fileprivate var cancellableSets: [Set<AnyCancellable>]
+
+        fileprivate var cancellable: Cancellable?
+
+        init(_ reference: Any,  _ subscriber: S, count: Int) {
+            self.reference = reference
+            self.subscriber = subscriber
+            self.cancellableSets = [Set<AnyCancellable>](repeating: [], count: count)
+        }
+
+        func cancel() {
+            reference = nil
+            cancellable = nil
+            subscriber = nil
+            cancellableSets = []
+        }
+
+        func request(_ demand: Subscribers.Demand) { }
+    }
+}
+
+#endif

--- a/LucidTestKit/Doubles/PayloadPersistenceManagerSpy.swift
+++ b/LucidTestKit/Doubles/PayloadPersistenceManagerSpy.swift
@@ -1,0 +1,27 @@
+//
+//  PayloadPersistenceManagerSpy.swift
+//  LucidTestKit
+//
+//  Created by Stephane Magne on 2/4/22.
+//  Copyright © 2022 Scribd. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Lucid
+
+final class PayloadPersistenceManagerSpy: RemoteStoreCachePayloadPersistenceManaging {
+
+    public init() {
+        // no-op
+    }
+
+    private(set) var persistEntitiesInvocations = [(
+        payload: AnyResultPayloadConvertible,
+        accessValidator: UserAccessValidating?
+    )]()
+
+    func persistEntities(from payload: AnyResultPayloadConvertible, accessValidator: UserAccessValidating?) {
+        persistEntitiesInvocations.append((payload, accessValidator))
+    }
+}

--- a/LucidTests/Utils/PublisherTests.swift
+++ b/LucidTests/Utils/PublisherTests.swift
@@ -15,6 +15,10 @@ final class PublisherTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable>!
 
+    private var optionalTest: Int?
+
+    private var arrayTest: [Int]!
+
     override func setUp() {
         super.setUp()
         cancellables = Set()
@@ -23,6 +27,8 @@ final class PublisherTests: XCTestCase {
     override func tearDown() {
         defer { super.tearDown() }
         cancellables = nil
+        optionalTest = nil
+        arrayTest = nil
     }
 
     func test_when_should_filter_entity_updates_on_index() {
@@ -504,6 +510,68 @@ final class PublisherTests: XCTestCase {
         subject.send(completion: .failure(.two))
 
         waitForExpectations(timeout: 0.2, handler: nil)
+    }
+
+    // MARK: - Assign Output
+
+    func test_assigning_optional_value_captures_success() {
+
+        optionalTest = 55
+
+        let subject = PassthroughSubject<Int?, FirstErrorType>()
+
+        subject
+            .assignOutput(to: \.optionalTest, on: self)
+            .store(in: &cancellables)
+
+        subject.send(10)
+
+        XCTAssertEqual(optionalTest, 10)
+    }
+
+    func test_assigning_optional_value_captures_failure_as_nil() {
+
+        optionalTest = 55
+
+        let subject = PassthroughSubject<Int?, FirstErrorType>()
+
+        subject
+            .assignOutput(to: \.optionalTest, on: self)
+            .store(in: &cancellables)
+
+        subject.send(completion: .failure(.one))
+
+        XCTAssertNil(optionalTest)
+    }
+
+    func test_assigning_array_value_captures_success() {
+
+        arrayTest = [55]
+
+        let subject = PassthroughSubject<[Int], FirstErrorType>()
+
+        subject
+            .assignOutput(to: \.arrayTest, on: self)
+            .store(in: &cancellables)
+
+        subject.send([1,2,3])
+
+        XCTAssertEqual(arrayTest, [1,2,3])
+    }
+
+    func test_assigning_array_value_captures_failure_as_empty_array() {
+
+        arrayTest = [55]
+
+        let subject = PassthroughSubject<[Int], FirstErrorType>()
+
+        subject
+            .assignOutput(to: \.arrayTest, on: self)
+            .store(in: &cancellables)
+
+        subject.send(completion: .failure(.one))
+
+        XCTAssertEqual(arrayTest, [])
     }
 }
 

--- a/LucidTests/Utils/PublisherTests.swift
+++ b/LucidTests/Utils/PublisherTests.swift
@@ -459,6 +459,7 @@ final class PublisherTests: XCTestCase {
 
         let subject = PassthroughSubject<[EntitySpy], FirstErrorType>()
         let outputExpectation = self.expectation(description: "output")
+        outputExpectation.expectedFulfillmentCount = 2
 
         subject
             .flatMapError { error -> Result<[EntitySpy], SecondErrorType> in
@@ -472,7 +473,7 @@ final class PublisherTests: XCTestCase {
                 case .failure:
                     XCTFail("Unexpected failure event")
                 case .finished:
-                    XCTFail("Unexpected finished event")
+                    outputExpectation.fulfill()
                 }
             }, receiveValue: { update in
                 XCTAssertEqual(update.count, 1)
@@ -580,6 +581,7 @@ final class PublisherTests: XCTestCase {
 
         let subject = PassthroughSubject<[EntitySpy], FirstErrorType>()
         let outputExpectation = self.expectation(description: "output")
+        outputExpectation.expectedFulfillmentCount = 2
 
         subject
             .flatMapError { error -> [EntitySpy] in
@@ -593,7 +595,7 @@ final class PublisherTests: XCTestCase {
                 case .failure:
                     XCTFail("Unexpected failure event")
                 case .finished:
-                    XCTFail("Unexpected finished event")
+                    outputExpectation.fulfill()
                 }
             }, receiveValue: { update in
                 XCTAssertEqual(update.count, 2)
@@ -727,6 +729,7 @@ final class PublisherTests: XCTestCase {
 
         let subject = PassthroughSubject<[EntitySpy], FirstErrorType>()
         let outputExpectation = self.expectation(description: "output")
+        outputExpectation.expectedFulfillmentCount = 2
 
         subject
             .mapToResult()
@@ -735,7 +738,7 @@ final class PublisherTests: XCTestCase {
                 case .failure:
                     XCTFail("Unexpected failure event")
                 case .finished:
-                    XCTFail("Unexpected finished event")
+                    outputExpectation.fulfill()
                 }
             }, receiveValue: { result in
                 switch result {


### PR DESCRIPTION
This adds some features to match extensions we created for ReactiveKit, and also to include some functionality that we found useful in ReactiveKit that doesn't have an equivalent in Combine. Such as:
- **func mapToResult()**
- **struct AMB**

This also adds features to support iOS 13 such as **flatMapError** (`flatMapError` can be replaced by `flatMap` in iOS 14, but can also exist as a standalone feature going forward).

