### PR TITLE
Trim xcdatamodel version history

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Generators/CoreDataMigrationTestsGenerator.swift
+++ b/CodeGen/Sources/LucidCodeGen/Generators/CoreDataMigrationTestsGenerator.swift
@@ -26,7 +26,14 @@ public final class CoreDataMigrationTestsGenerator: Generator {
     }
 
     public func generate(for element: Description, in directory: Path, organizationName: String) throws -> SwiftFile? {
-        guard parameters.shouldGenerateDataModel else { return nil }
+        // If shouldGenerateDataModel == false, then we will rebuild the migration tests using the previous version number.
+        // This allows the migration tests to be regenerated when old data models have been trimmed.
+        let appVersion: Version
+        if parameters.shouldGenerateDataModel {
+            appVersion = parameters.appVersion
+        } else {
+            appVersion = parameters.newestModelVersion
+        }
         guard element == .all else { return nil }
 
         let header = MetaHeader(filename: filename, organizationName: organizationName)
@@ -39,8 +46,9 @@ public final class CoreDataMigrationTestsGenerator: Generator {
 
         let coreDataMigrationTests = MetaCoreDataMigrationTests(descriptions: parameters.currentDescriptions,
                                                                 sqliteVersions: sqliteVersions,
-                                                                appVersion: parameters.appVersion,
+                                                                appVersion: appVersion,
                                                                 oldestModelVersion: parameters.oldestModelVersion,
+                                                                newestModelVersion: parameters.newestModelVersion,
                                                                 platform: parameters.platform)
         
         return Meta.File(name: filename)

--- a/CodeGen/Sources/LucidCodeGenCore/ExtensionGenerator.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/ExtensionGenerator.swift
@@ -27,6 +27,8 @@ public struct GeneratorParameters: Codable {
 
     public let oldestModelVersion: Version
 
+    public let newestModelVersion: Version
+
     public let platform: Platform?
 
     public let shouldGenerateDataModel: Bool
@@ -45,6 +47,7 @@ public struct GeneratorParameters: Codable {
                 historyVersions: [Version],
                 targetModuleName: String,
                 oldestModelVersion: Version,
+                newestModelVersion: Version,
                 platform: Platform?,
                 shouldGenerateDataModel: Bool,
                 sqliteFile: Path,
@@ -59,6 +62,7 @@ public struct GeneratorParameters: Codable {
         self.historyVersions = historyVersions
         self.targetModuleName = targetModuleName
         self.oldestModelVersion = oldestModelVersion
+        self.newestModelVersion = newestModelVersion
         self.platform = platform
         self.shouldGenerateDataModel = shouldGenerateDataModel
         self.sqliteFile = sqliteFile


### PR DESCRIPTION
Previously we had added support to remove any deleted xcdatamodels from the CoreDataMigrationTests, but it was incomplete. It only worked if you were also creating a new xcdatamodel version at the same time.

We didn't notice this in the past because we were altering the data model so frequently.

Now the logic will work in both of these scenarios:

1. The developer has removed some older xcdatamodels but **has not** made any changes to the descriptions for the current version. This will rebuild the CoreData migration tests using the `previous` model build number.


2. The developer has removed some older xcdatamodels and **has also** made some changes to the descriptions for the current version. This will rebuild the CoreData migration tests using the `current` build number.