### PR TITLE
Add default nil value to metadata on Graph initializer

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityGraph.swift
+++ b/CodeGen/Sources/LucidCodeGen/Meta/MetaEntityGraph.swift
@@ -274,6 +274,10 @@ struct MetaEntityGraph {
                 variable: .named(.`self`) + .named("rootEntities"),
                 value: Value.array([])
             ))
+            .adding(member: Assignment(
+                variable: .named(.`self`) + .named("_metadata"),
+                value: Value.nil
+            ))
     }
 
     private func insertFunction() -> Function {


### PR DESCRIPTION
No comments... just Swift doing it's things

It seems like `Optional<T>` doesn't default to `nil` as the `?` does