### PR TITLE
[IPT-7266] Implement Async/Await functions for CoreManager

### DIFF
--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01ED569B29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
+		01ED569C29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
+		01ED569D29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
+		01ED569E29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
 		1907AD8424A682D300727F82 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1907AD8224A6826400727F82 /* Configuration.swift */; };
 		1907AD8624A682DB00727F82 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1907AD8224A6826400727F82 /* Configuration.swift */; };
 		190ADC0D2458D71000D22F6D /* Lucid.h in Headers */ = {isa = PBXBuildFile; fileRef = 190ADC0B2458D71000D22F6D /* Lucid.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -413,6 +417,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01ED569A29E9C3FA00C77548 /* Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		1907AD8224A6826400727F82 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		190ADC082458D71000D22F6D /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		190ADC0B2458D71000D22F6D /* Lucid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Lucid.h; sourceTree = "<group>"; };
@@ -928,6 +933,7 @@
 				190ADC492458D89C00D22F6D /* Result.swift */,
 				190ADC502458D89C00D22F6D /* ScheduledTimer.swift */,
 				190ADC4D2458D89C00D22F6D /* Timestamp.swift */,
+				01ED569A29E9C3FA00C77548 /* Async.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2090,6 +2096,7 @@
 				190ADC5D2458D89C00D22F6D /* APIClientQueue.swift in Sources */,
 				190ADC7C2458D89C00D22F6D /* ScheduledTimer.swift in Sources */,
 				190ADC6E2458D89C00D22F6D /* CoreDataStore.swift in Sources */,
+				01ED569B29E9C3FA00C77548 /* Async.swift in Sources */,
 				190ADC712458D89C00D22F6D /* DataStructures.swift in Sources */,
 				190ADC6B2458D89C00D22F6D /* RecoverableStore.swift in Sources */,
 				F438471027E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */,
@@ -2209,6 +2216,7 @@
 				190ADD092458DA9B00D22F6D /* APIClientQueue.swift in Sources */,
 				190ADD0A2458DA9B00D22F6D /* ScheduledTimer.swift in Sources */,
 				190ADD0B2458DA9B00D22F6D /* CoreDataStore.swift in Sources */,
+				01ED569E29E9C3FA00C77548 /* Async.swift in Sources */,
 				190ADD0C2458DA9B00D22F6D /* DataStructures.swift in Sources */,
 				190ADD0D2458DA9B00D22F6D /* RecoverableStore.swift in Sources */,
 				F438471227E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */,
@@ -2324,6 +2332,7 @@
 				F48C80412655958E00581182 /* CancellationToken.swift in Sources */,
 				F48C803A2655958E00581182 /* DataStructures.swift in Sources */,
 				F48C80342655958E00581182 /* DiskQueue.swift in Sources */,
+				01ED569C29E9C3FA00C77548 /* Async.swift in Sources */,
 				F48C80402655958E00581182 /* Result.swift in Sources */,
 				F48C802E2655958A00581182 /* RecoverableStore.swift in Sources */,
 				F438470F27E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */,
@@ -2379,6 +2388,7 @@
 				F48C809A2655972700581182 /* Contract.swift in Sources */,
 				F48C808C2655972700581182 /* Color.swift in Sources */,
 				F48C808A2655972700581182 /* Entity.swift in Sources */,
+				01ED569D29E9C3FA00C77548 /* Async.swift in Sources */,
 				F48C80942655972700581182 /* Codable.swift in Sources */,
 				F48C80C02655973000581182 /* Result.swift in Sources */,
 				F48C808F2655972700581182 /* Version.swift in Sources */,

--- a/Lucid/Utils/Async.swift
+++ b/Lucid/Utils/Async.swift
@@ -1,0 +1,229 @@
+//
+//  Async.swift
+//  Lucid
+//
+//  Created by Ezequiel Munz on 14/04/2023.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Async Tasks Storage
+
+public final actor AsyncTasks {
+
+    private var tasks: [Task<Void, any Error>] = []
+
+    deinit {
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    public init() { }
+
+    public func cancel() {
+        for task in tasks {
+            task.cancel()
+        }
+    }
+}
+
+fileprivate extension AsyncTasks {
+
+    func append(_ task: Task<Void, any Error>) {
+        tasks.append(task)
+    }
+}
+
+public extension Task where Success == Void, Failure == any Error {
+
+    @discardableResult
+    func store(in asyncTasks: AsyncTasks) -> Self {
+        Task {
+            await asyncTasks.append(self)
+        }
+        return self
+    }
+}
+
+// MARK: - AsyncTasksQueue
+
+public actor AsyncTaskQueue {
+
+    private let maxConcurrentTasks: Int
+    private var runningTasks: Int = 0
+    private var queue = [CheckedContinuation<Void, Error>]()
+
+    public init(maxConcurrentTasks: Int = 1) {
+        self.maxConcurrentTasks = maxConcurrentTasks
+    }
+
+    deinit {
+        for continuation in queue {
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    public func enqueue<T>(operation: @escaping @Sendable () async throws -> T) async throws -> T {
+        try Task.checkCancellation()
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            queue.append(continuation)
+            tryRunEnqueued()
+        }
+
+        defer {
+            runningTasks -= 1
+            tryRunEnqueued()
+        }
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    private func tryRunEnqueued() {
+        guard queue.isEmpty == false else { return }
+        guard runningTasks < maxConcurrentTasks else { return }
+
+        runningTasks += 1
+        let continuation = queue.removeFirst()
+        continuation.resume()
+    }
+}
+
+// MARK: - Sequence
+
+public extension Sequence {
+
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values = [T]()
+
+        for element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+
+    func concurrentMap<T>(_ transform: @escaping (Element) async throws -> T) async throws -> [T] {
+        let tasks = map { element in
+            Task {
+                try await transform(element)
+            }
+        }
+
+        return try await tasks.asyncMap { task in
+            try await task.value
+        }
+    }
+}
+
+public extension Sequence {
+
+    func asyncForEach(_ operation: (Element) async throws -> Void) async rethrows {
+        for element in self {
+            try await operation(element)
+        }
+    }
+
+    func concurrentForEach(_ operation: @escaping (Element) async -> Void) async {
+        // A task group automatically waits for all of its
+        // sub-tasks to complete, while also performing those
+        // tasks in parallel:
+        await withTaskGroup(of: Void.self) { group in
+            for element in self {
+                group.addTask {
+                    await operation(element)
+                }
+            }
+        }
+    }
+}
+
+public extension AsyncSequence {
+
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values = [T]()
+
+        for try await element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+
+    func concurrentMap<T>(_ transform: @escaping (Element) async throws -> T) async throws -> [T] {
+        let tasks = map { element in
+            Task {
+                try await transform(element)
+            }
+        }
+
+        return try await tasks.asyncMap { task in
+            try await task.value
+        }
+    }
+}
+
+
+// MARK: - Combine Bridge
+
+/// `AsyncSequence` implementation that bridges an Upstream Publisher with Failure type = `Never` into an async sequence
+/// The outcome sequence is an `AsyncStream` type that won't throw any error in the way
+///
+/// This is useful if we want to use Swift Concurrency when the inputs are coming as Combine publishers
+public class AsyncSafeStreamPublisherBridge<Upstream: Publisher>: AsyncSequence where Upstream.Failure == Never {
+
+    public typealias Element = Upstream.Output
+    public typealias AsyncIterator = AsyncSafeStreamPublisherBridge<Upstream>
+
+    public let stream: AsyncStream<Upstream.Output>
+    private lazy var iterator = stream.makeAsyncIterator()
+
+    private var cancellable: AnyCancellable?
+
+    public init(_ upstream: Upstream) {
+        var subscription: AnyCancellable?
+
+        stream = AsyncStream<Upstream.Output>(Upstream.Output.self) { continuation in
+            subscription = upstream.handleEvents(receiveCancel: {
+                continuation.finish()
+            })
+            .sink(receiveValue: { value in
+                continuation.yield(value)
+            })
+        }
+
+        cancellable = subscription
+    }
+
+    deinit {
+        cancel()
+    }
+
+    public func makeAsyncIterator() -> Self {
+        return self
+    }
+
+    public func cancel() {
+        cancellable?.cancel()
+        cancellable = nil
+    }
+}
+
+// - MARK: - Conformance to `AsyncIteratorProtocol`
+
+extension AsyncSafeStreamPublisherBridge: AsyncIteratorProtocol {
+    public func next() async -> Upstream.Output? {
+        return await iterator.next()
+    }
+}
+
+// MARK: - Publisher Extensions
+
+public extension Publisher where Failure == Never {
+    func asyncStream() -> AsyncSafeStreamPublisherBridge<Self> {
+        return AsyncSafeStreamPublisherBridge(self)
+    }
+}

--- a/LucidTestKit/Doubles/CoreManagerSpy.swift
+++ b/LucidTestKit/Doubles/CoreManagerSpy.swift
@@ -15,25 +15,48 @@ public final class CoreManagerSpy<E: Entity> {
 
     public typealias AnyEntityType = AnyEntitySpy
 
+    public enum AsyncResult<T> {
+        case value(_: T)
+        case error(_: ManagerError)
+    }
+
     // MARK: Stubs
 
     public var getEntityStub: AnyPublisher<QueryResult<E>, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var getEntityStubs: [AnyPublisher<QueryResult<E>, ManagerError>]?
 
+    public var getEntityAsyncStub: AsyncResult<QueryResult<E>> = .error(.notSupported)
+    public var getEntityAsyncStubs: [AsyncResult<QueryResult<E>>]?
+
     public var setEntityStub: AnyPublisher<E, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var setEntityStubs: [AnyPublisher<E, ManagerError>]?
+
+    public var setEntityAsyncStub: AsyncResult<E> = .error(.notSupported)
+    public var setEntityAsyncStubs: [AsyncResult<E>]?
 
     public var setEntitiesStub: AnyPublisher<AnySequence<E>, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var setEntitiesStubs: [AnyPublisher<AnySequence<E>, ManagerError>]?
 
+    public var setEntitiesAsyncStub: AsyncResult<AnySequence<E>> = .error(.notSupported)
+    public var setEntitiesAsyncStubs: [AsyncResult<AnySequence<E>>]?
+
     public var removeAllStub: AnyPublisher<AnySequence<E.Identifier>, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var removeAllStubs: [AnyPublisher<AnySequence<E.Identifier>, ManagerError>]?
+
+    public var removeAllAsyncStub: AsyncResult<AnySequence<E.Identifier>> = .error(.notSupported)
+    public var removeAllAsyncStubs: [AsyncResult<AnySequence<E.Identifier>>]?
 
     public var removeEntityStub: AnyPublisher<Void, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var removeEntityStubs: [AnyPublisher<Void, ManagerError>]?
 
+    public var removeEntityAsyncStub: AsyncResult<Void> = .error(.notSupported)
+    public var removeEntityAsyncStubs: [AsyncResult<Void>]?
+
     public var removeEntitiesStub: AnyPublisher<Void, ManagerError> = Fail(error: .notSupported).eraseToAnyPublisher()
     public var removeEntitiesStubs: [AnyPublisher<Void, ManagerError>]?
+
+    public var removeEntitiesAsyncStub: AsyncResult<Void> = .error(.notSupported)
+    public var removeEntitiesAsyncStubs: [AsyncResult<Void>]?
 
     public var searchStub: (
         once: AnyPublisher<QueryResult<E>, ManagerError>,
@@ -48,21 +71,41 @@ public final class CoreManagerSpy<E: Entity> {
         continuous: AnyPublisher<QueryResult<E>, Never>
     )]?
 
+    public var searchAsyncStub: (
+        once: () async throws -> QueryResult<E>,
+        continuous: AsyncStream<QueryResult<E>>
+    ) = (
+        once: { throw ManagerError.notSupported },
+        continuous: AsyncStream<QueryResult<E>>(unfolding: { return nil })
+    )
+
+    public var searchAsyncStubs: [(
+        once: () async throws -> QueryResult<E>,
+        continuous: AsyncStream<QueryResult<E>>
+    )]?
+
     // MARK: Records
 
     public var getEntityRecords: [GetRecord] = []
+    public var getEntityAsyncRecords: [GetRecord] = []
 
     public var setEntityRecords: [SetRecord] = []
+    public var setEntityAsyncRecords: [SetRecord] = []
 
     public var setEntitiesRecords: [SetRecord] = []
+    public var setEntitiesAsyncRecords: [SetRecord] = []
 
     public var removeAllRecords: [RemoveAllRecord] = []
+    public var removeAllAsyncRecords: [RemoveAllRecord] = []
 
     public var removeEntityRecords: [RemoveRecord] = []
+    public var removeEntityAsyncRecords: [RemoveRecord] = []
 
     public var removeEntitiesRecords: [RemoveRecord] = []
+    public var removeEntitiesAsyncRecords: [RemoveRecord] = []
 
     public var searchRecords: [SearchRecord] = []
+    public var searchAsyncRecords: [SearchRecord] = []
 
     // MARK: API
 
@@ -76,10 +119,28 @@ public final class CoreManagerSpy<E: Entity> {
         return getEntityStubs?.getOrFail(at: getEntityRecords.count - 1) ?? getEntityStub
     }
 
+    public func get(withQuery query: Query<E>,
+                    in context: ReadContext<E>) async throws -> QueryResult<E> {
+        getEntityAsyncRecords.append(GetRecord(query: query, context: context))
+        let stub = getEntityAsyncStubs?.getOrFail(at: getEntityAsyncRecords.count - 1) ?? getEntityAsyncStub
+        switch stub {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        }
+    }
+
     public func search(withQuery query: Query<E>,
                        in context: ReadContext<E>) -> (once: AnyPublisher<QueryResult<E>, ManagerError>, continuous: AnyPublisher<QueryResult<E>, Never>) {
         searchRecords.append(SearchRecord(query: query, context: context))
         return searchStubs?.getOrFail(at: searchRecords.count - 1) ?? searchStub
+    }
+
+    public func search(withQuery query: Query<E>,
+                       in context: ReadContext<E>) async throws -> (once: () async throws -> QueryResult<E>, continuous: AsyncStream<QueryResult<E>>) {
+        searchAsyncRecords.append(SearchRecord(query: query, context: context))
+        return searchAsyncStubs?.getOrFail(at: searchAsyncRecords.count - 1) ?? searchAsyncStub
     }
 
     public func set(_ entity: E,
@@ -88,10 +149,34 @@ public final class CoreManagerSpy<E: Entity> {
         return setEntityStubs?.getOrFail(at: setEntityRecords.count - 1) ?? setEntityStub
     }
 
+    public func set(_ entity: E,
+                    in context: WriteContext<E>) async throws -> E {
+        setEntityAsyncRecords.append(SetRecord(entity: [entity], context: context))
+        let stub = setEntityAsyncStubs?.getOrFail(at: setEntityRecords.count - 1) ?? setEntityAsyncStub
+        switch stub {
+        case .value(let entity):
+            return entity
+        case .error(let error):
+            throw error
+        }
+    }
+
     public func set<S>(_ entities: S,
                        in context: WriteContext<E>) -> AnyPublisher<AnySequence<E>, ManagerError> where S: Sequence, S.Element == E {
         setEntitiesRecords.append(SetRecord(entity: entities.array, context: context))
         return setEntitiesStubs?.getOrFail(at: setEntitiesRecords.count - 1) ?? setEntitiesStub
+    }
+
+    public func set<S>(_ entities: S,
+                       in context: WriteContext<E>) async throws -> AnySequence<E> where S: Sequence, S.Element == E {
+        setEntitiesAsyncRecords.append(SetRecord(entity: entities.array, context: context))
+        let stub = setEntitiesAsyncStubs?.getOrFail(at: setEntitiesAsyncRecords.count - 1) ?? setEntitiesAsyncStub
+        switch stub {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        }
     }
 
     public func removeAll(withQuery query: Query<E>,
@@ -100,16 +185,52 @@ public final class CoreManagerSpy<E: Entity> {
         return removeAllStubs?.getOrFail(at: removeAllRecords.count - 1) ?? removeAllStub
     }
 
+    public func removeAll(withQuery query: Query<E>,
+                          in context: WriteContext<E>) async throws -> AnySequence<E.Identifier> {
+        removeAllAsyncRecords.append(RemoveAllRecord(query: query, context: context))
+        let stub = removeAllAsyncStubs?.getOrFail(at: removeAllAsyncRecords.count - 1) ?? removeAllAsyncStub
+        switch stub {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        }
+    }
+
     public func remove(atID identifier: E.Identifier,
                        in context: WriteContext<E>) -> AnyPublisher<Void, ManagerError> {
         removeEntityRecords.append(RemoveRecord(identifier: [identifier], context: context))
         return removeEntityStubs?.getOrFail(at: removeEntityRecords.count - 1) ?? removeEntityStub
     }
 
+    public func remove(atID identifier: E.Identifier,
+                       in context: WriteContext<E>) async throws {
+        removeEntityAsyncRecords.append(RemoveRecord(identifier: [identifier], context: context))
+        let stub = removeEntityAsyncStubs?.getOrFail(at: removeEntityAsyncRecords.count - 1) ?? removeEntityAsyncStub
+        switch stub {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        }
+    }
+
     public func remove<S>(_ identifiers: S,
                           in context: WriteContext<E>) -> AnyPublisher<Void, ManagerError> where S: Sequence, S.Element == E.Identifier {
         removeEntityRecords.append(RemoveRecord(identifier: identifiers.array, context: context))
         return removeEntitiesStubs?.getOrFail(at: removeEntityRecords.count - 1) ?? removeEntitiesStub
+    }
+
+    public func remove<S>(_ identifiers: S,
+                          in context: WriteContext<E>) async throws where S: Sequence, S.Element == E.Identifier {
+        removeEntityAsyncRecords.append(RemoveRecord(identifier: identifiers.array, context: context))
+        let stub = removeEntitiesAsyncStubs?.getOrFail(at: removeEntityAsyncRecords.count - 1) ?? removeEntitiesAsyncStub
+        switch stub {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        }
     }
 }
 
@@ -160,12 +281,19 @@ public extension CoreManagerSpy {
 
     func managing<AnyEntityType>() -> CoreManaging<E, AnyEntityType> where AnyEntityType: EntityConvertible {
         return CoreManaging(getEntity: { self.get(withQuery: $0, in: $1) },
+                            getEntityAsync: { try await self.get(withQuery: $0, in: $1) },
                             searchEntities: { self.search(withQuery: $0, in: $1) },
+                            searchEntitiesAsync: { try await self.search(withQuery: $0, in: $1) },
                             setEntity: { self.set($0, in: $1) },
+                            setEntityAsync: { try await self.set($0, in: $1) },
                             setEntities: { self.set($0, in: $1) },
+                            setEntitiesAsync: { try await self.set($0, in: $1) },
                             removeAllEntities: { self.removeAll(withQuery: $0, in: $1) },
-                            removeEntity: { self.remove(atID: $0, in: $1)},
+                            removeAllEntitiesAsync: { try await self.removeAll(withQuery: $0, in: $1) },
+                            removeEntity: { self.remove(atID: $0, in: $1) },
+                            removeEntityAsync: { try await self.remove(atID: $0, in: $1) },
                             removeEntities: { self.remove($0, in: $1) },
+                            removeEntitiesAsync: { try await self.remove($0, in: $1) },
                             relationshipManager: nil)
     }
 }

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -23,6 +23,8 @@ final class CoreManagerTests: XCTestCase {
 
     private var cancellables: Set<AnyCancellable>!
 
+    private var asyncTasks: AsyncTasks!
+
     override func setUp() {
         super.setUp()
 
@@ -35,6 +37,7 @@ final class CoreManagerTests: XCTestCase {
         memoryStoreSpy.levelStub = .memory
 
         cancellables = Set()
+        asyncTasks = AsyncTasks()
 
         manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
     }
@@ -46,6 +49,7 @@ final class CoreManagerTests: XCTestCase {
         memoryStoreSpy = nil
         manager = nil
         cancellables = nil
+        asyncTasks = nil
     }
 
     // MARK: - get(byID:in:cacheStrategy:completion:)
@@ -697,6 +701,460 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [continuousExpectation, waitExpectation], timeout: 1)
     }
 
+    // MARK: - get(byID:in:cacheStrategy:completion:) async throws -> QueryResult<E>
+
+    func test_manager_should_get_entity_from_remote_store_then_cache_it_when_cache_strategy_is_remote_only_async() async {
+
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertEqual(result.entity?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_remote_store_then_not_cache_it_and_fall_back_to_memory_store_when_cache_strategy_is_remote_or_local_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+        memoryStoreSpy.getResultStub = .success(.empty())
+
+        let context = ReadContext<EntitySpy>(dataSource: .remoteOrLocal(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_remote_store_then_not_cache_it_when_data_source_is_remote_only_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entity_from_remote_store_only_when_cache_strategy_is_remote_only_async() async {
+
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertEqual(result.entity?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_remote_store_when_cache_strategy_is_remote_only_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+        memoryStoreSpy.getResultStub = .success(.empty())
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entity_from_memory_store_only_when_strategy_is_local_only_async() async {
+
+        memoryStoreSpy.getResultStub = .success(.empty())
+
+        let context = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNil(result.entity)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entity_from_memory_store_then_not_cache_it_when_strategy_is_local_only_async() async {
+
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+
+        let context = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertEqual(result.entity?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_memory_store_then_not_cache_it_when_strategy_is_local_only_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        memoryStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+
+        let context = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entity_from_memory_first_then_from_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertEqual(result.entity?.identifier.value.remoteValue, 42)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.last?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_get_entity_from_memory_first_but_still_reach_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.getResultStub = .success(.empty())
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNotNil(result.entity)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_return_nil_from_cache_but_should_return_nil_from_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.getResultStub = .success(.empty())
+        memoryStoreSpy.removeResultStub = .success(())
+        remoteStoreSpy.getResultStub = .success(.empty())
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNil(result.entity)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_memory_first_but_ignore_error_and_reach_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: APIClientResponse(data: Data(), cachedResponse: false)
+        )))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil))))
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let _ = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entity_from_memory_first_but_ignore_error_and_return_remote_store_error_when_strategy_is_local_then_remote_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        memoryStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+        remoteStoreSpy.getResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_returns_local_values_if_local_result_count_matches_identifier_count_when_observing_once_signal_and_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil)), EntitySpy(idValue: .remote(44, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("ids", .value(["42", "43"]))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_returns_remote_values_if_local_result_count_does_not_match_identifier_count_when_observing_once_signal_and_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil))]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("ids", .value(["42", "43"]))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_returns_both_remote_results_and_local_results_when_observing_continuous_signal_and_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil))]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(43, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("ids", .value(["42", "43"]))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let stream = try await self.manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).continuous
+
+                    for await result in stream {
+                        XCTAssertEqual(result.count, 2)
+                        XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+                        XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
+                        return
+                    }
+                }
+
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                }
+
+                try await group.next()
+                group.cancelAll()
+            }
+
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_continuous_observer_emits_once_when_results_are_the_same_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil))]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("ids", .value(["42", "43"]))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil))]
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let stream = try await self.manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).continuous
+                    for await result in stream {
+                        XCTAssertEqual(result.count, 1)
+                        XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+                        return
+                    }
+                }
+
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                }
+
+                try await group.next()
+                group.cancelAll()
+            }
+
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - search(withQuery:context:cacheStrategy:completion:)
 
     func test_manager_should_get_entities_from_remote_store_then_cache_them_when_strategy_is_remote_only() {
@@ -1081,6 +1539,258 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation], timeout: 1)
+    }
+
+    // MARK: - search(withQuery:context:cacheStrategy:completion:) async throws -> (once:continuous:)
+
+    func test_manager_should_get_entities_from_remote_store_then_cache_them_when_strategy_is_remote_only_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entities_when_remote_store_fails_and_strategy_is_remote_only_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.searchResultStub = .failure(.notSupported)
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entities_when_stores_fails_and_strategy_is_remote_or_local_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.searchResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: APIClientResponse(data: Data(), cachedResponse: false)
+        )))
+        memoryStoreSpy.searchResultStub = .failure(.notSupported)
+
+        let context = ReadContext<EntitySpy>(dataSource: .remoteOrLocal(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.composite(current: .notSupported, previous: .api(.api(httpStatusCode: 500, errorPayload: nil, response: response)))) {
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_v3_manager_should_fail_to_get_entities_when_stores_fails_and_data_source_is_remote_only_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.searchResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: APIClientResponse(data: Data(), cachedResponse: false)
+        )))
+        memoryStoreSpy.searchResultStub = .failure(.notSupported)
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entities_from_remote_store_when_strategy_is_remote_only_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entities_when_remote_store_fails_and_strategy_is_remote_only_with_do_not_persist_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+        memoryStoreSpy.searchResultStub = .failure(.notSupported)
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_fail_to_get_entities_when_stores_fails_and_strategy_is_remote_only_async() async {
+
+        let response = APIClientResponse(data: Data(), cachedResponse: false)
+        remoteStoreSpy.searchResultStub = .failure(.api(.api(
+            httpStatusCode: 500, errorPayload: nil, response: response
+        )))
+        memoryStoreSpy.searchResultStub = .failure(.notSupported)
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entities_from_memory_store_then_not_cache_them_when_strategy_is_local_only_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]))
+
+        let context = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_get_entities_from_memory_then_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        let entities = [EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]
+        memoryStoreSpy.searchResultStub = .success(.entities(entities))
+        remoteStoreSpy.searchResultStub = .success(.entities(entities))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+
+            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_ignore_empty_entities_from_memory_then_get_entities_from_remote_store_when_strategy_is_local_then_remote_async() async {
+
+        let entities = [EntitySpy(idValue: .remote(42, nil)), EntitySpy(idValue: .remote(42, nil))]
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+        remoteStoreSpy.searchResultStub = .success(.entities(entities))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(result.count, 2)
+
+            try? await Task.sleep(nanoseconds: 50000)
+
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - Providers
@@ -1758,6 +2468,520 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation, continuousExpectation], timeout: 1)
     }
 
+    // MARK: - Providers Async
+
+    func test_manager_should_send_entity_update_to_provider_when_strategy_is_local_then_remote_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")]))
+
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    try await Task.sleep(nanoseconds: 500000)
+
+                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
+                    XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    for await result in signals.continuous {
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.title, "updated_fake_title")
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                        continuousCallCount += 1
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_when_entity_changed_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")))
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult.first?.title, "updated_fake_title")
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.title, "updated_fake_title")
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_send_entity_update_to_provider_when_entity_did_not_change_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), title: "fake_title")
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: entity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult.first?.title, "fake_title")
+                }
+
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.first?.title, "fake_title")
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_with_different_query_when_entity_changed_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title ~= .string(".*fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")))
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult.first?.title, "updated_fake_title")
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.title, "updated_fake_title")
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_with_different_query_when_entity_is_not_in_filter_anymore_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title == .string("fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")))
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult.first?.title, "updated_fake_title")
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.count, 0)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_send_entity_update_to_provider_with_different_query_when_entity_did_not_change_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title == .string("fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "fake_title")))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult.first?.title, "fake_title")
+                }
+
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.first?.title, "fake_title")
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_with_different_query_when_entity_is_not_found_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title == .string("fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.memoryStoreSpy.getResultStub = .success(.empty())
+                    self.memoryStoreSpy.removeResultStub = .success(())
+                    self.remoteStoreSpy.getResultStub = .success(.empty())
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    let getResult = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                    XCTAssertEqual(getResult, .empty())
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.count, 0)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_when_entity_is_removed_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title == .string("fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    self.memoryStoreSpy.removeResultStub = .success(())
+                    self.remoteStoreSpy.removeResultStub = .success(())
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+                    try await self.manager.remove(atID: EntitySpyIdentifier(value: .remote(42, nil)), in: WriteContext(dataTarget: .local))
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.count, 0)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_when_entity_is_set_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(
+                method: .get,
+                path: .path("fake_entity"),
+                query: [("query", .value("fake_title"))]
+            ), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.title ~= .string(".*fake_title")), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                    XCTAssertEqual(result.count, 1)
+
+                    let newDocument = EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")
+                    self.memoryStoreSpy.setResultStub = .success([newDocument])
+                    self.remoteStoreSpy.setResultStub = .success([newDocument])
+                    self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+                    _ = try await self.manager.set(newDocument, in: WriteContext(dataTarget: .local))
+                }
+
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    for await result in signals.continuous {
+                        defer { continuousCallCount += 1 }
+
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.title, "updated_fake_title")
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - Partial vs Complete Results
 
     func test_manager_should_send_new_truth_to_all_query_for_complete_results() {
@@ -2045,6 +3269,229 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [continuousExpectation3], timeout: 1)
     }
 
+    // MARK: - Partial vs Complete Results Async
+
+    func test_manager_should_send_new_truth_to_all_query_for_complete_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    let allQueryContext = ReadContext<EntitySpy>(dataSource: .local)
+                    let allQuerySignals = try await self.manager.search(withQuery: .all, in: allQueryContext)
+
+                    for await result in allQuerySignals.continuous {
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.title, "another_fake_title")
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                        continuousCallCount += 1
+                    }
+                }
+
+                // First update
+                group.addTask {
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+                    let firstContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.discardExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                }
+
+                // Second update
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 10000)
+
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")])
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.discardExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    XCTAssertEqual(result.first?.title, "another_fake_title")
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_new_truth_to_all_query_for_contextual_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    let allQueryContext = ReadContext<EntitySpy>(dataSource: .local)
+                    let allQuerySignals = try await self.manager.search(withQuery: .all, in: allQueryContext)
+
+                    for await result in allQuerySignals.continuous {
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            let titles = result.map { $0.title }
+                            XCTAssertTrue(titles.contains("fake_title"))
+                            XCTAssertTrue(titles.contains("another_fake_title"))
+                            XCTAssertEqual(result.count, 2)
+                            return
+                        }
+                        continuousCallCount += 1
+                    }
+                }
+                // First Update
+                group.addTask {
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+                    let firstContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.retainExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                }
+
+                // Second Update
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 10000)
+
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")])
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.retainExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    XCTAssertEqual(result.first?.title, "another_fake_title")
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_new_truth_to_all_query_for_paginated_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    var continuousCallCount = 0
+
+                    let allQueryContext = ReadContext<EntitySpy>(dataSource: .local)
+                    let allQuerySignals = try await self.manager.search(withQuery: .all, in: allQueryContext)
+
+                    for await result in allQuerySignals.continuous {
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.first?.title, "fake_title")
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            let titles = result.map { $0.title }
+                            XCTAssertTrue(titles.contains("fake_title"))
+                            XCTAssertTrue(titles.contains("another_fake_title"))
+                            XCTAssertEqual(result.count, 2)
+                            return
+                        }
+                        continuousCallCount += 1
+                    }
+                }
+
+                // First Update
+                group.addTask {
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
+
+                    let firstContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(
+                                method: .get,
+                                path: .path("fake_entity"),
+                                query: [("page", .value("1"))]
+                            ), resultPayload: .empty),
+                            persistenceStrategy: .persist(.retainExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    XCTAssertEqual(result.first?.title, "fake_title")
+                }
+
+                // Second Update
+                group.addTask {
+                    try await Task.sleep(nanoseconds: 10000)
+
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")]))
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+                    self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")])
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(
+                                method: .get,
+                                path: .path("fake_entity"),
+                                query: [("page", .value("1"))]
+                            ), resultPayload: .empty),
+                            persistenceStrategy: .persist(.retainExtraLocalData)
+                        )
+                    )
+
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    XCTAssertEqual(result.first?.title, "another_fake_title")
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: Deleting local records on search
 
     func test_manager_should_delete_non_matching_synced_local_records_for_complete_results() {
@@ -2207,6 +3654,146 @@ final class CoreManagerTests: XCTestCase {
         XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
         XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
         XCTAssertTrue(memoryStoreSpy.identifierRecords.isEmpty)
+    }
+
+    // MARK: Deleting local records on search Async
+
+    func test_manager_should_delete_non_matching_synced_local_records_for_complete_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(3, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(4, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(5, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.setResultStub = .success([])
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            )
+        )
+
+        do {
+            _ = try await manager.search(withQuery: .all, in: context).once()
+
+            XCTAssertEqual(memoryStoreSpy.removeCallCount, 1)
+            XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 3)
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.contains(EntitySpyIdentifier(value: .remote(3, nil))))
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.contains(EntitySpyIdentifier(value: .remote(4, nil))))
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.contains(EntitySpyIdentifier(value: .remote(5, nil))))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_delete_non_matching_out_of_sync_local_records_for_complete_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(3, nil), remoteSynchronizationState: .outOfSync),
+            EntitySpy(idValue: .remote(4, nil), remoteSynchronizationState: .outOfSync),
+            EntitySpy(idValue: .remote(5, nil), remoteSynchronizationState: .outOfSync)
+        ]))
+        memoryStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.setResultStub = .success([])
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            )
+        )
+
+        do {
+            _ = try await manager.search(withQuery: .all, in: context).once()
+
+            XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
+            XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_delete_non_matching_synced_local_records_for_contextual_results_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(3, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(4, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(5, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.setResultStub = .success([])
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                persistenceStrategy: .persist(.retainExtraLocalData)
+            )
+        )
+
+        do {
+            _ = try await manager.search(withQuery: .all, in: context).once()
+
+            XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
+            XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_delete_non_matching_synced_local_records_for_paginated_results_aysnc() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(1, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(2, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(3, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(4, nil), remoteSynchronizationState: .synced),
+            EntitySpy(idValue: .remote(5, nil), remoteSynchronizationState: .synced)
+        ]))
+        memoryStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.setResultStub = .success([])
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                persistenceStrategy: .persist(.retainExtraLocalData)
+            )
+        )
+
+        do {
+            _ = try await manager.search(withQuery: .all, in: context)
+
+            XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
+            XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
+            XCTAssertTrue(memoryStoreSpy.identifierRecords.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - Query Ordering
@@ -2429,6 +4016,206 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    // MARK: - Query Ordering Async
+
+    func test_results_should_be_returned_in_query_order_ascending_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let query = Query<EntitySpy>(filter: .all,
+                                     order: [.asc(by: .index(.title))])
+
+        let firstContext = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
+
+                    for await result in continuous {
+                        guard result.count == 3 else {
+                            XCTFail("Expected 3 entities")
+                            return
+                        }
+
+                        XCTAssertEqual(result.array[0].title, "another_fake_title")
+                        XCTAssertEqual(result.array[1].title, "fake_title")
+                        XCTAssertEqual(result.array[2].title, "some_fake_title")
+                        return
+                    }
+                }
+
+                // Update
+                group.addTask {
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([])
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([
+                        EntitySpy(idValue: .remote(42, nil), title: "fake_title"),
+                        EntitySpy(idValue: .remote(43, nil), title: "another_fake_title"),
+                        EntitySpy(idValue: .remote(44, nil), title: "some_fake_title")
+                    ]))
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.discardExtraLocalData)
+                        )
+                    )
+
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_results_should_be_returned_in_multiple_query_order_ascending_identifiers_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let query = Query<EntitySpy>(filter: .all,
+                                     order: [.asc(by: .index(.title)),
+                                             .asc(by: .identifier)])
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    let firstContext = ReadContext<EntitySpy>(dataSource: .local)
+                    let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
+
+                    for await result in continuous {
+                        guard result.count == 3 else {
+                            XCTFail("Expected 3 entities")
+                            return
+                        }
+
+                        XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+                        XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
+                        XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
+                        return
+                    }
+                }
+
+                // Update
+                group.addTask {
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([])
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([
+                        EntitySpy(idValue: .remote(42, nil), title: "fake_title"),
+                        EntitySpy(idValue: .remote(43, nil), title: "another_fake_title"),
+                        EntitySpy(idValue: .remote(44, nil), title: "fake_title")
+                    ]))
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.discardExtraLocalData)
+                        )
+                    )
+
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_results_should_be_returned_in_multiple_query_order_descending_identifiers_async() async {
+
+        remoteStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let query = Query<EntitySpy>(filter: .all,
+                                     order: [.asc(by: .index(.title)),
+                                             .desc(by: .identifier)])
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continous Listener
+                group.addTask {
+                    let firstContext = ReadContext<EntitySpy>(dataSource: .local)
+                    let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
+
+                    for await result in continuous {
+                        guard result.count == 3 else {
+                            XCTFail("Expected 3 entities")
+                            return
+                        }
+
+                        XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+                        XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
+                        XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
+                        return
+                    }
+                }
+
+                // Update
+                group.addTask {
+                    self.memoryStoreSpy.searchResultStub = .success(.entities([]))
+                    self.memoryStoreSpy.setResultStub = .success([])
+                    self.remoteStoreSpy.searchResultStub = .success(.entities([
+                        EntitySpy(idValue: .remote(42, nil), title: "fake_title"),
+                        EntitySpy(idValue: .remote(43, nil), title: "another_fake_title"),
+                        EntitySpy(idValue: .remote(44, nil), title: "fake_title")
+                    ]))
+
+                    let secondContext = ReadContext<EntitySpy>(
+                        dataSource: .remote(
+                            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                            persistenceStrategy: .persist(.discardExtraLocalData)
+                        )
+                    )
+
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_results_should_be_returned_in_query_order_natural_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+        memoryStoreSpy.setResultStub = .success([])
+        remoteStoreSpy.searchResultStub = .success(.entities([
+            EntitySpy(idValue: .remote(43, nil), title: "fake_title"),
+            EntitySpy(idValue: .remote(42, nil), title: "another_fake_title"),
+            EntitySpy(idValue: .remote(44, nil), title: "some_fake_title")
+        ]))
+
+        let secondContext = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            )
+        )
+
+        do {
+            let result = try await manager.search(withQuery: .all, in: secondContext).once()
+
+            XCTAssertEqual(result.map { $0.title }, [
+                "fake_title",
+                "another_fake_title",
+                "some_fake_title"
+            ])
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - Disposing
 
     func test_search_should_release_continuous_provider_as_soon_as_the_observer_is_disposed() {
@@ -2554,6 +4341,140 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation], timeout: 1)
     }
 
+    // MARK: - Disposing Async
+
+    func test_search_should_release_continuous_provider_as_soon_as_the_observer_is_disposed_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        memoryStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+        remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let continuousExpectation = self.expectation(description: "continuous")
+        continuousExpectation.isInverted = true
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .localThen(.remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ))
+        )
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            Task {
+                _ = try? await signals.once()
+
+                for await _ in signals.continuous {
+                    continuousExpectation.fulfill()
+                }
+            }.store(in: asyncTasks)
+
+            await asyncTasks.cancel()
+
+            wait(for: [continuousExpectation], timeout: 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_should_release_once_provider_as_soon_as_the_observer_is_disposed_async() async {
+
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
+        remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "updated_fake_title")]))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        memoryStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+        remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let onceExpectation = self.expectation(description: "once")
+        onceExpectation.isInverted = true
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .localThen(.remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ))
+        )
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            Task {
+                _ = try await signals.once()
+
+                onceExpectation.fulfill()
+            }.store(in: asyncTasks)
+
+            await asyncTasks.cancel()
+
+            wait(for: [onceExpectation], timeout: 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_should_release_once_provider_as_soon_as_the_observer_is_disposed_async() async {
+
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "fake_title")))
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: EntitySpy(idValue: .remote(42, nil), title: "fake_title")))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        memoryStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+        remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let onceExpectation = self.expectation(description: "once")
+        onceExpectation.isInverted = true
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .localThen(.remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ))
+        )
+
+
+        Task {
+            _ = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+
+            onceExpectation.fulfill()
+        }.store(in: asyncTasks)
+
+        await asyncTasks.cancel()
+
+        wait(for: [onceExpectation], timeout: 1)
+    }
+
+    func test_set_should_release_once_provider_as_soon_as_the_observer_is_disposed_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), title: "fake_title")
+        memoryStoreSpy.setResultStub = .success([entity])
+        remoteStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        memoryStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+        remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let onceExpectation = self.expectation(description: "once")
+        onceExpectation.isInverted = true
+
+        Task {
+            _ = try await manager.set(entity, in: WriteContext(dataTarget: .local))
+            onceExpectation.fulfill()
+        }.store(in: asyncTasks)
+
+        await asyncTasks.cancel()
+
+        wait(for: [onceExpectation], timeout: 1)
+    }
+
     // MARK: - Observer Ordering
 
     func test_continuous_observer_should_receive_all_updates_in_order() {
@@ -2604,6 +4525,61 @@ final class CoreManagerTests: XCTestCase {
         }
 
         wait(for: [continuousExpectation], timeout: 60)
+    }
+
+    // MARK: - Observer Ordering Async
+
+    func test_continuous_observer_should_receive_all_updates_in_order_async() async {
+        let count = 400
+
+        let expectedResults = (0..<count).map { index in
+            (0..<index).map { EntitySpy(idValue: .remote($0, nil), title: "title_\($0)") }
+        }
+
+        let memoryStore = InMemoryStore<EntitySpy>()
+        manager = CoreManager(stores: [memoryStore.storing]).managing()
+
+        let context = ReadContext<EntitySpy>(dataSource: .local)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous
+                group.addTask {
+                    var continuousCallCount = 0
+                    let signals = try await self.manager.search(withQuery: .all, in: context)
+                    _ = try await signals.once()
+                    for await result in signals.continuous {
+                        guard continuousCallCount < count else {
+                            XCTFail("received too many responses")
+                            return
+                        }
+                        XCTAssertEqual(result.any, expectedResults[continuousCallCount].any)
+                        continuousCallCount += 1
+                        print(continuousCallCount)
+                        if continuousCallCount >= count {
+                            return
+                        }
+                    }
+                }
+
+                // Updates
+                group.addTask {
+                    let entities = (0..<count).map { EntitySpy(idValue: .remote($0, nil), title: "title_\($0)") }
+
+                    await entities.asyncForEach { entity in
+                        do {
+                            try await self.manager.set(entity, in: WriteContext(dataTarget: .local))
+                        } catch {
+                            XCTFail("Unexpected error: \(error)")
+                        }
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - Metadata Root Filtering
@@ -2698,6 +4674,69 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation], timeout: 1)
     }
 
+    // MARK: GET Async
+
+    func test_get_request_returns_request_token_and_metadata_for_remote_only_strategy_with_do_no_persist_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.getResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_request_returns_request_token_and_metadata_for_remote_only_strategy_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.getResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+        memoryStoreSpy.getResultStub = .success(QueryResult<EntitySpy>(from: entity))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_request_returns_request_token_and_metadata_for_local_then_remote_and_local_store_fails_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.getResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+        memoryStoreSpy.getResultStub = .failure(.invalidCoreDataEntity)
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: SEARCH
 
     func test_search_request_returns_request_token_and_metadata_for_remote_only_strategy_with_do_not_persist() {
@@ -2779,6 +4818,69 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation], timeout: 1)
     }
 
+    // MARK: SEARCH async
+
+    func test_search_request_returns_request_token_and_metadata_for_remote_only_strategy_with_do_not_persist_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .all, in: context).once()
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_request_returns_request_token_and_metadata_for_remote_only_strategy_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+        memoryStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity))
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let result = try await manager.search(withQuery: .all, in: context).once()
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_request_returns_request_token_and_metadata_for_local_then_remote_strategy_and_local_store_fails_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+        memoryStoreSpy.searchResultStub = .failure(.invalidCoreDataEntity)
+        memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil))])
+
+        let context = ReadContext<EntitySpy>(dataSource: .localThen(.remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        )))
+
+        do {
+            let result = try await manager.search(withQuery: .all, in: context).once()
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: All Entities Convenience
 
     func test_all_entities_convenience_request_returns_request_token_and_metadata_for_remote_only_strategy() {
@@ -2803,6 +4905,27 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation], timeout: 1)
+    }
+
+    // MARK: All Entities Convenience async
+
+    func test_all_entities_convenience_request_returns_request_token_and_metadata_for_remote_only_strategy_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.all(in: context)
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: Entities Convenience
@@ -2832,6 +4955,27 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation], timeout: 1)
     }
 
+    // MARK: Entities Convenience Async
+
+    func test_entities_convenience_request_returns_request_token_and_metadata_for_remote_only_strategy_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.get(byIDs: [EntitySpyIdentifier(value: .remote(42, nil))], in: context).once()
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: First With Metadata Convenience
 
     func test_first_with_metadata_convenience_request_returns_request_token_and_metadata_for_remote_only_strategy() {
@@ -2856,6 +5000,27 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation], timeout: 1)
+    }
+
+    // MARK: First With Metadata Convenience Async
+
+    func test_first_with_metadata_convenience_request_returns_request_token_and_metadata_for_remote_only_strategy_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+
+        remoteStoreSpy.searchResultStub = .success(QueryResult<EntitySpy>(from: entity, metadata: stubMetadata))
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .doNotPersist
+        ))
+
+        do {
+            let result = try await manager.firstWithMetadata(in: context)
+            XCTAssertNotNil(result.metadata)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: Test Updates For Extras Changes
@@ -3261,6 +5426,284 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation, continuousExpectation], timeout: 1)
+    }
+
+    // MARK: Test Updates For Extras Changes Async
+
+    func test_manager_should_not_send_entity_update_to_provider_when_lazy_value_changes_from_unrequested_to_unrequested_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), lazy: .unrequested)
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.first?.lazy, .unrequested)
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                // Once Update
+                group.addTask {
+                    let result = try await signals.once()
+                    XCTAssertEqual(result.first?.lazy, .unrequested)
+                    XCTAssertEqual(result.count, 1)
+
+                    let updatedEntity = EntitySpy(idValue: .remote(42, nil), lazy: .unrequested)
+                    let mergedEntity = entity.merging(updatedEntity)
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: mergedEntity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+
+                    _ = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_send_entity_update_to_provider_when_lazy_value_changes_from_requested_to_unrequested_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(6))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listening
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.first?.lazy, .requested(6))
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                // Once update
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.lazy, .requested(6))
+                    XCTAssertEqual(result.count, 1)
+
+                    let updatedEntity = EntitySpy(idValue: .remote(42, nil), lazy: .unrequested)
+                    let mergedEntity = entity.merging(updatedEntity)
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: mergedEntity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+                    _ = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_not_send_entity_update_to_provider_when_lazy_value_changes_from_requested_to_same_requested_value_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(6))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.first?.lazy, .requested(6))
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                // Once update
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.lazy, .requested(6))
+                    XCTAssertEqual(result.count, 1)
+
+                    let updatedEntity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(6))
+                    let mergedEntity = entity.merging(updatedEntity)
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: mergedEntity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+                    _ = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_when_lazy_value_changes_from_unrequested_to_requested_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), lazy: .unrequested)
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    var continuousCount = 0
+
+                    for await result in signals.continuous {
+                        if continuousCount == 0 {
+                            XCTAssertEqual(result.first?.lazy, .unrequested)
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.lazy, .requested(5))
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                        continuousCount += 1
+                    }
+                }
+
+                // Once update
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.lazy, .unrequested)
+                    XCTAssertEqual(result.count, 1)
+
+                    let updatedEntity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(5))
+                    let mergedEntity = entity.merging(updatedEntity)
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: mergedEntity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+                    _ = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_manager_should_send_entity_update_to_provider_when_lazy_value_changes_from_requested_to_new_requested_value_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(7))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource: .remote(
+            endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+            persistenceStrategy: .persist(.discardExtraLocalData)
+        ))
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    var continuousCount = 0
+
+                    for await result in signals.continuous {
+                        if continuousCount == 0 {
+                            XCTAssertEqual(result.first?.lazy, .requested(7))
+                            XCTAssertEqual(result.count, 1)
+                        } else {
+                            XCTAssertEqual(result.first?.lazy, .requested(99))
+                            XCTAssertEqual(result.count, 1)
+                            return
+                        }
+                        continuousCount += 1
+                    }
+                }
+
+                // Once update
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.first?.lazy, .requested(7))
+                    XCTAssertEqual(result.count, 1)
+
+                    let updatedEntity = EntitySpy(idValue: .remote(42, nil), lazy: .requested(99))
+                    let mergedEntity = entity.merging(updatedEntity)
+                    self.remoteStoreSpy.getResultStub = .success(QueryResult(from: mergedEntity))
+                    let getContext = ReadContext<EntitySpy>(dataSource: .remote(
+                        endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                        persistenceStrategy: .persist(.discardExtraLocalData)
+                    ))
+                    _ = try await self.manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: getContext)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - UserAccessLevels - Requests
@@ -4100,6 +6543,555 @@ final class CoreManagerTests: XCTestCase {
         wait(for: [onceExpectation], timeout: 1)
     }
 
+    // MARK: - UserAccessLevels - Requests Async
+
+    func test_get_returns_remote_data_for_remote_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+
+            XCTAssertNotNil(result.entity)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_returns_local_data_for_local_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remoteOrLocal(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+
+            XCTAssertNotNil(result.entity)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_returns_error_for_no_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected value: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_returns_remote_data_for_remote_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                // Once Update
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.count, 1)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 1)
+                    XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_returns_local_data_for_local_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remoteOrLocal(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous Listener
+                group.addTask {
+                    for await result in signals.continuous {
+                        XCTAssertEqual(result.count, 1)
+                        return
+                    }
+                }
+
+                // Once
+                group.addTask {
+                    let result = try await signals.once()
+
+                    XCTAssertEqual(result.count, 1)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 0)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 0)
+                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 1)
+                    XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_returns_failure_for_once_and_no_data_for_continuous_for_no_access_level_async() async {
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        let continuousExpectation = self.expectation(description: "Continuous")
+        continuousExpectation.isInverted = true
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remote(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Continuous
+                group.addTask {
+                    for await result in signals.continuous {
+                        continuousExpectation.fulfill()
+                        XCTFail("Unexpected value: \(result)")
+                    }
+                }
+
+                // Once
+                group.addTask {
+                    let result = try await signals.once()
+                    XCTFail("Unexpected value: \(result)")
+                }
+
+                try await group.waitForAll()
+            }
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        wait(for: [continuousExpectation], timeout: 1.0)
+    }
+
+    func test_user_access_validation_set_returns_remote_response_for_remote_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+
+        do {
+            _ = try await manager.set(entity, in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_set_returns_local_response_for_local_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        do {
+            _ = try await manager.set(entity, in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_set_returns_failure_for_no_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        do {
+            let result = try await manager.set(entity, in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+            XCTFail("Unexpected value: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_set_array_returns_remote_response_for_remote_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+
+        do {
+            _ = try await manager.set([entity], in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_set_array_returns_local_response_for_local_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        do {
+            _ = try await manager.set([entity], in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+
+            XCTAssertEqual(self.remoteStoreSpy.entityRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_set_array_returns_failure_for_no_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        do {
+            let result = try await manager.set([entity], in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+            XCTFail("Unexpected value: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_returns_remote_response_for_remote_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove(atID: entity.identifier, in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_returns_local_response_for_local_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove(atID: entity.identifier, in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_returns_failure_for_no_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove(atID: entity.identifier, in: context)
+            XCTFail("Unexpected result")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_array_returns_remote_response_for_remote_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove([entity.identifier], in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_array_returns_local_response_for_local_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove([entity.identifier], in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.identifierRecords.first?.value.remoteValue, 42)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_array_returns_failure_for_no_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            try await manager.remove([entity.identifier], in: context)
+            XCTFail("Unexpected result")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_all_returns_remote_response_for_remote_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeAllResultStub = .success([entity.identifier])
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.removeAllResultStub = .success([entity.identifier])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+        let query: Query<EntitySpy> = .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+
+        do {
+            _ = try await manager.removeAll(withQuery: query, in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.last?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_all_returns_local_response_for_local_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeAllResultStub = .success([entity.identifier])
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.removeAllResultStub = .success([entity.identifier])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .localAccess
+
+        let query: Query<EntitySpy> = .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            _ = try await manager.removeAll(withQuery: query, in: context)
+
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 0)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.last?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_user_access_validation_remove_all_returns_failure_for_no_access_level_async() async {
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeAllResultStub = .success([entity.identifier])
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.removeAllResultStub = .success([entity.identifier])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = .noAccess
+
+        let query: Query<EntitySpy> = .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
+        let context = WriteContext<EntitySpy>(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+
+        do {
+            let result = try await manager.removeAll(withQuery: query, in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - UserAccessLevels - Requests
 
     func performGetForAccessLevelChange(from request: UserAccess, to response: UserAccess) {
@@ -4409,6 +7401,258 @@ final class CoreManagerTests: XCTestCase {
         performRemoveAllForAccessLevelChange(from: .localAccess, to: .noAccess)
     }
 
+    // MARK: - UserAccessLevels - Requests Async
+
+    func performGetForAccessLevelChange(from request: UserAccess, to response: UserAccess) async {
+        let remoteStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        remoteStoreSpy.levelStub = .remote
+        let memoryStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        memoryStoreSpy.levelStub = .memory
+
+        manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.getResultStub = .success(QueryResult(from: entity))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = request
+        remoteStoreSpy.userAccessSpy = validatorSpy
+        remoteStoreSpy.userAccessAfterStoreResponse = response
+        memoryStoreSpy.userAccessSpy = validatorSpy
+        memoryStoreSpy.userAccessAfterStoreResponse = response
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remoteOrLocal(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_returns_failure_for_change_from_remote_access_to_local_access_async() async {
+        await performGetForAccessLevelChange(from: .remoteAccess, to: .localAccess)
+    }
+
+    func test_get_returns_failure_for_change_from_remote_access_to_no_access_async() async {
+        await performGetForAccessLevelChange(from: .remoteAccess, to: .noAccess)
+    }
+
+    func test_get_returns_failure_for_change_from_local_access_to_remote_access_async() async {
+        await performGetForAccessLevelChange(from: .localAccess, to: .remoteAccess)
+    }
+
+    func test_get_returns_failure_for_change_from_local_access_to_no_access_async() async {
+        await performGetForAccessLevelChange(from: .localAccess, to: .noAccess)
+    }
+
+    func performSearchForAccessLevelChange(from request: UserAccess, to response: UserAccess) async {
+        let remoteStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        remoteStoreSpy.levelStub = .remote
+        let memoryStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        memoryStoreSpy.levelStub = .memory
+        manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = request
+        remoteStoreSpy.userAccessSpy = validatorSpy
+        remoteStoreSpy.userAccessAfterStoreResponse = response
+        memoryStoreSpy.userAccessSpy = validatorSpy
+        memoryStoreSpy.userAccessAfterStoreResponse = response
+
+        let context = ReadContext<EntitySpy>(
+            dataSource: .remoteOrLocal(
+                endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                persistenceStrategy: .persist(.discardExtraLocalData)
+            ),
+            accessValidator: validatorSpy
+        )
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_returns_failure_for_change_from_remote_access_to_local_access_async() async {
+        await performSearchForAccessLevelChange(from: .remoteAccess, to: .localAccess)
+    }
+
+    func test_search_returns_failure_for_change_from_remote_access_to_no_access_async() async {
+        await performSearchForAccessLevelChange(from: .remoteAccess, to: .noAccess)
+    }
+
+    func test_search_returns_failure_for_change_from_local_access_to_remote_access_async() async {
+        await performSearchForAccessLevelChange(from: .localAccess, to: .remoteAccess)
+    }
+
+    func test_search_returns_failure_for_change_from_local_access_to_no_access_async() async {
+        await performSearchForAccessLevelChange(from: .localAccess, to: .noAccess)
+    }
+
+    func performSetForAccessLevelChange(from request: UserAccess, to response: UserAccess) async {
+        let remoteStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        remoteStoreSpy.levelStub = .remote
+        let memoryStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        memoryStoreSpy.levelStub = .memory
+        manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.setResultStub = .success([entity])
+        memoryStoreSpy.setResultStub = .success([entity])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = request
+        remoteStoreSpy.userAccessSpy = validatorSpy
+        remoteStoreSpy.userAccessAfterStoreResponse = response
+        memoryStoreSpy.userAccessSpy = validatorSpy
+        memoryStoreSpy.userAccessAfterStoreResponse = response
+
+        do {
+            let result = try await manager
+                .set(
+                    entity,
+                    in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+                )
+
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error")
+        }
+    }
+
+    func test_set_returns_failure_for_change_from_remote_access_to_local_access_async() async {
+        await performSetForAccessLevelChange(from: .remoteAccess, to: .localAccess)
+    }
+
+    func test_set_returns_failure_for_change_from_remote_access_to_no_access_async() async {
+        await performSetForAccessLevelChange(from: .remoteAccess, to: .noAccess)
+    }
+
+    func test_set_returns_failure_for_change_from_local_access_to_remote_access_async() async {
+        await performSetForAccessLevelChange(from: .localAccess, to: .remoteAccess)
+    }
+
+    func test_set_returns_failure_for_change_from_local_access_to_no_access_async() async {
+        await performSetForAccessLevelChange(from: .localAccess, to: .noAccess)
+    }
+
+    func performRemoveForAccessLevelChange(from request: UserAccess, to response: UserAccess) async {
+        let remoteStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        remoteStoreSpy.levelStub = .remote
+        let memoryStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        memoryStoreSpy.levelStub = .memory
+        manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeResultStub = .success(())
+        memoryStoreSpy.removeResultStub = .success(())
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = request
+        remoteStoreSpy.userAccessSpy = validatorSpy
+        remoteStoreSpy.userAccessAfterStoreResponse = response
+        memoryStoreSpy.userAccessSpy = validatorSpy
+        memoryStoreSpy.userAccessAfterStoreResponse = response
+
+        do {
+            try await manager.remove(atID: entity.identifier, in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy))
+            XCTFail("Unexpected result")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_remove_returns_failure_for_change_from_remote_access_to_local_access_async() async {
+        await performRemoveForAccessLevelChange(from: .remoteAccess, to: .localAccess)
+    }
+
+    func test_remove_returns_failure_for_change_from_remote_access_to_no_access_async() async {
+        await performRemoveForAccessLevelChange(from: .remoteAccess, to: .noAccess)
+    }
+
+    func test_remove_returns_failure_for_change_from_local_access_to_remote_access_async() async {
+        await performRemoveForAccessLevelChange(from: .localAccess, to: .remoteAccess)
+    }
+
+    func test_remove_returns_failure_for_change_from_local_access_to_no_access_async() async {
+        await performRemoveForAccessLevelChange(from: .localAccess, to: .noAccess)
+    }
+
+    func performRemoveAllForAccessLevelChange(from request: UserAccess, to response: UserAccess) async {
+        let remoteStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        remoteStoreSpy.levelStub = .remote
+        let memoryStoreSpy = UserAccessInvalidatingStoreSpy<EntitySpy>()
+        memoryStoreSpy.levelStub = .memory
+        manager = CoreManager(stores: [remoteStoreSpy.storing, memoryStoreSpy.storing]).managing()
+
+        let entity = EntitySpy(idValue: .remote(42, nil))
+        remoteStoreSpy.removeAllResultStub = .success([entity.identifier])
+        memoryStoreSpy.searchResultStub = .success(.entities([entity]))
+        memoryStoreSpy.removeAllResultStub = .success([entity.identifier])
+
+        let validatorSpy = UserAccessValidatorSpy()
+        validatorSpy.stub = request
+        remoteStoreSpy.userAccessSpy = validatorSpy
+        remoteStoreSpy.userAccessAfterStoreResponse = response
+        memoryStoreSpy.userAccessSpy = validatorSpy
+        memoryStoreSpy.userAccessAfterStoreResponse = response
+
+        do {
+            let result = try await manager
+                .removeAll(
+                    withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))),
+                    in: WriteContext(dataTarget: .localAndRemote(endpoint: .derivedFromEntityType), accessValidator: validatorSpy)
+                )
+
+            XCTFail("Unexpected result: \(result)")
+        } catch let error as ManagerError {
+            XCTAssertEqual(error, .userAccessInvalid)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_remove_all_returns_failure_for_change_from_remote_access_to_local_access_async() async {
+        await performRemoveAllForAccessLevelChange(from: .remoteAccess, to: .localAccess)
+    }
+
+    func test_remove_all_returns_failure_for_change_from_remote_access_to_no_access_async() async {
+        await performRemoveAllForAccessLevelChange(from: .remoteAccess, to: .noAccess)
+    }
+
+    func test_remove_all_returns_failure_for_change_from_local_access_to_remote_access_async() async {
+        await performRemoveAllForAccessLevelChange(from: .localAccess, to: .remoteAccess)
+    }
+
+    func test_remove_all_returns_failure_for_change_from_local_access_to_no_access_async() async {
+        await performRemoveAllForAccessLevelChange(from: .localAccess, to: .noAccess)
+    }
+
     // MARK: - Fall back to local errors
     // MARK: get: local --> remote
 
@@ -4559,6 +7803,107 @@ final class CoreManagerTests: XCTestCase {
 
         wait(for: [onceExpectation], timeout: 1)
     }
+
+    // MARK: - Fall back to local errors async
+    // MARK: get: local --> remote | async
+
+    func test_get_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.getResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.getResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.getResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.getResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await  manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_empty_response_error_async() async {
+        remoteStoreSpy.getResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.getResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_get_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_empty_response_error_async() async {
+        remoteStoreSpy.getResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.getResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: search: local --> remote
 
     func test_search_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error() {
@@ -4877,6 +8222,219 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation], timeout: 1)
+    }
+
+    // MARK: search: local --> remote | async
+
+    func test_search_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.search(
+                withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))),
+                in: context
+            ).once()
+
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.search(
+                withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))),
+                in: context
+            ).once()
+
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_or_remote_returns_partial_local_result_when_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_then_remote_returns_partial_local_result_when_receiving_internet_connection_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.api(.network(.networkConnectionFailure(.networkConnectionLost))))
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_or_remote_returns_nil_result_if_local_result_missing_and_receiving_empty_response_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_then_remote_returns_nil_result_if_local_result_missing_and_receiving_empty_response_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.searchResultStub = .success(.entities([]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            XCTAssertTrue(result.isEmpty)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_or_remote_returns_partial_local_result_when_receiving_empty_response_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localOr(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_search_local_then_remote_returns_partial_local_result_when_receiving_empty_response_error_async() async {
+        remoteStoreSpy.searchResultStub = .failure(.emptyResponse)
+        memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil))]))
+
+        let dispatchQueue = DispatchQueue(label: "CoreManagerTestsQueue")
+        self.remoteStoreSpy.stubAsynchronousCompletionQueue = dispatchQueue
+
+        let context = ReadContext<EntitySpy>(dataSource:
+            .localThen(
+                .remote(
+                    endpoint: .request(APIRequestConfig(method: .get, path: .path("fake_entity/42")), resultPayload: .empty),
+                    persistenceStrategy: .persist(.discardExtraLocalData)
+                )
+            )
+        )
+
+        let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
+        do {
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - Continuous Observation Race Condition Test


### PR DESCRIPTION
This PR adds the async/await versions of the core manager queries

- Get
- Search
- Set
- Remove
- RemoveAll

Note: If we want to go further on the implementation, we should start to create async/await versions of the `Stores`