### PR TITLE
Make sure we create unique CancellableBoxes

### DIFF
--- a/Lucid/Utils/Publishers+Extensions.swift
+++ b/Lucid/Utils/Publishers+Extensions.swift
@@ -102,7 +102,7 @@ private extension Publishers.AMB {
         init(_ reference: Any,  _ subscriber: S, count: Int) {
             self.reference = reference
             self.subscriber = subscriber
-            self._cancellableBoxes = [CancellableBox](repeating: CancellableBox(), count: count)
+            self._cancellableBoxes = (0..<count).map { _ in CancellableBox() }
         }
 
         var cancellableBoxes: [CancellableBox] {


### PR DESCRIPTION
I made a classic blunder, and the existing tests weren't correctly written and they didn't catch it, so I've fixed the bug and fixed the test.

This line of code will create an array, but passing the same value to each item in the array. This will copy for `structs`, but pass the same memory reference for `classes`. Whoops!

```swift
[CancellableBox](repeating: CancellableBox(), count: count)
```

whereas this will create a unique object for every item in the array:

```swift
(0..<count).map { _ in CancellableBox() }
```