### PR TITLE
Replace CoreManagerProperty with Swift Concurrency Version

### DIFF
--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		F438471027E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438470E27E15D5C00D6EB98 /* CoreManagerProperty.swift */; };
 		F438471127E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438470E27E15D5C00D6EB98 /* CoreManagerProperty.swift */; };
 		F438471227E15D5C00D6EB98 /* CoreManagerProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F438470E27E15D5C00D6EB98 /* CoreManagerProperty.swift */; };
+		F43FFE8F2A1413C60000AAC2 /* AsyncCurrentValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43FFE8E2A1413C60000AAC2 /* AsyncCurrentValueTests.swift */; };
 		F440173827A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
 		F440173927A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
 		F440173A27A4A7A600B9D983 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */; };
@@ -281,6 +282,10 @@
 		F48C80BF2655973000581182 /* AnyEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC532458D89C00D22F6D /* AnyEquatable.swift */; };
 		F48C80C02655973000581182 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC492458D89C00D22F6D /* Result.swift */; };
 		F48C80C12655973000581182 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADC472458D89C00D22F6D /* Logger.swift */; };
+		F4939A552A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */; };
+		F4939A562A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */; };
+		F4939A572A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */; };
+		F4939A582A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */; };
 		F4A7587A2914746F0046DE3F /* APIClientQueueResponseHandlerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCCE2458D9A500D22F6D /* APIClientQueueResponseHandlerSpy.swift */; };
 		F4A7587B2914746F0046DE3F /* APIClientQueueSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCC02458D9A500D22F6D /* APIClientQueueSpy.swift */; };
 		F4A7587C2914746F0046DE3F /* RelationshipCoreManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCBC2458D9A500D22F6D /* RelationshipCoreManagerSpy.swift */; };
@@ -733,6 +738,7 @@
 		F417CD3027EBD5660077210C /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		F417CD3527EBD69F0077210C /* CombineHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineHelperTests.swift; sourceTree = "<group>"; };
 		F438470E27E15D5C00D6EB98 /* CoreManagerProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreManagerProperty.swift; sourceTree = "<group>"; };
+		F43FFE8E2A1413C60000AAC2 /* AsyncCurrentValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncCurrentValueTests.swift; sourceTree = "<group>"; };
 		F440173727A4A7A600B9D983 /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
 		F45FA8FA24EC8D3C00368CCB /* Contract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contract.swift; sourceTree = "<group>"; };
 		F47A447D291473ED0031286B /* LucidTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LucidTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -740,6 +746,7 @@
 		F48C717624896F5400099980 /* CoreManagerContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreManagerContractTests.swift; sourceTree = "<group>"; };
 		F48C7FFA2655948200581182 /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F48C8058265596D700581182 /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncCurrentValue.swift; sourceTree = "<group>"; };
 		F4A40EBF2513B8700025E48C /* CodingPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodingPathTests.swift; sourceTree = "<group>"; };
 		F4A75898291477960046DE3F /* LucidTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LucidTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4A7589A291477960046DE3F /* LucidTestKit_tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LucidTestKit_tvOS.h; sourceTree = "<group>"; };
@@ -920,6 +927,8 @@
 			children = (
 				190ADC532458D89C00D22F6D /* AnyEquatable.swift */,
 				190ADC462458D89C00D22F6D /* AnySequence.swift */,
+				01ED569A29E9C3FA00C77548 /* Async.swift */,
+				F4939A542A12EC4200C69D0E /* AsyncCurrentValue.swift */,
 				190ADC4B2458D89C00D22F6D /* AsyncOperationQueue.swift */,
 				190ADC4F2458D89C00D22F6D /* BackgroundTaskManager.swift */,
 				F417CD3027EBD5660077210C /* Cancellable.swift */,
@@ -935,7 +944,6 @@
 				190ADC492458D89C00D22F6D /* Result.swift */,
 				190ADC502458D89C00D22F6D /* ScheduledTimer.swift */,
 				190ADC4D2458D89C00D22F6D /* Timestamp.swift */,
-				01ED569A29E9C3FA00C77548 /* Async.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -986,6 +994,7 @@
 		190ADC9C2458D8FE00D22F6D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F43FFE8E2A1413C60000AAC2 /* AsyncCurrentValueTests.swift */,
 				19ED00962481C3D10033B7BD /* AsyncOperationQueueTests.swift */,
 				F4B987462A0EAA3000421E20 /* AsyncTaskQueueTests.swift */,
 				191F919324C12AAA0050C7C6 /* BackgroundTaskManagerTests.swift */,
@@ -2089,6 +2098,7 @@
 				190ADC7D2458D89C00D22F6D /* CancellationToken.swift in Sources */,
 				190ADC7B2458D89C00D22F6D /* BackgroundTaskManager.swift in Sources */,
 				190ADC7A2458D89C00D22F6D /* DiskCache.swift in Sources */,
+				F4939A552A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */,
 				190ADC552458D89C00D22F6D /* Query.swift in Sources */,
 				190ADC6F2458D89C00D22F6D /* RemoteStore.swift in Sources */,
 				190ADC562458D89C00D22F6D /* Metadata.swift in Sources */,
@@ -2141,6 +2151,7 @@
 				1987FA642555DD410057F1CC /* APIClientQueueTests.swift in Sources */,
 				1987FA142554A5230057F1CC /* CoreDataStoreTests.swift in Sources */,
 				1987FA382554A5740057F1CC /* StoreStackTests.swift in Sources */,
+				F43FFE8F2A1413C60000AAC2 /* AsyncCurrentValueTests.swift in Sources */,
 				F417CD3627EBD69F0077210C /* CombineHelperTests.swift in Sources */,
 				1987FA022554A4F50057F1CC /* PublisherTests.swift in Sources */,
 				1987FA3E2554A5810057F1CC /* RelationshipControllerTests.swift in Sources */,
@@ -2210,6 +2221,7 @@
 				190ADCFE2458DA9B00D22F6D /* CancellationToken.swift in Sources */,
 				190ADCFF2458DA9B00D22F6D /* BackgroundTaskManager.swift in Sources */,
 				190ADD002458DA9B00D22F6D /* DiskCache.swift in Sources */,
+				F4939A582A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */,
 				190ADD012458DA9B00D22F6D /* Query.swift in Sources */,
 				190ADD022458DA9B00D22F6D /* RemoteStore.swift in Sources */,
 				190ADD032458DA9B00D22F6D /* Metadata.swift in Sources */,
@@ -2326,6 +2338,7 @@
 				F48C80212655958500581182 /* CoreDataConversion.swift in Sources */,
 				F48C80142655958500581182 /* Color.swift in Sources */,
 				F48C80362655958E00581182 /* PropertyBox.swift in Sources */,
+				F4939A562A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */,
 				F48C803D2655958E00581182 /* Logger.swift in Sources */,
 				F48C80272655958500581182 /* HTTPTypes.swift in Sources */,
 				F48C801C2655958500581182 /* Context.swift in Sources */,
@@ -2382,6 +2395,7 @@
 				F48C809D2655972700581182 /* APIClientQueueDefaultScheduler.swift in Sources */,
 				F48C80BA2655973000581182 /* DiskCache.swift in Sources */,
 				F48C80892655972700581182 /* CoreManager.swift in Sources */,
+				F4939A572A12EC4200C69D0E /* AsyncCurrentValue.swift in Sources */,
 				F48C80962655972700581182 /* ManagerResult.swift in Sources */,
 				F48C80882655972700581182 /* Context.swift in Sources */,
 				F48C80A92655972B00581182 /* CoreDataStore.swift in Sources */,

--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		F4A758DD291479460046DE3F /* EntityRelationshipSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCBF2458D9A500D22F6D /* EntityRelationshipSpy.swift */; };
 		F4A758DE291479490046DE3F /* StubCoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F47E5EF924AA57BC007DCC4A /* StubCoreDataModel.xcdatamodeld */; };
 		F4A758DF2914794D0046DE3F /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1987FA452554A7210057F1CC /* Combine.swift */; };
+		F4B987472A0EAA3000421E20 /* AsyncTaskQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B987462A0EAA3000421E20 /* AsyncTaskQueueTests.swift */; };
 		F4EF380727ADCCF000964191 /* PayloadPersistenceManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */; };
 		F4FEEF9A27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
 		F4FEEF9B27D9A1BA00812A6E /* Publishers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */; };
@@ -744,6 +745,7 @@
 		F4A7589A291477960046DE3F /* LucidTestKit_tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LucidTestKit_tvOS.h; sourceTree = "<group>"; };
 		F4A758BF2914791E0046DE3F /* LucidTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LucidTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4A758C12914791E0046DE3F /* LucidTestKit_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LucidTestKit_macOS.h; sourceTree = "<group>"; };
+		F4B987462A0EAA3000421E20 /* AsyncTaskQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTaskQueueTests.swift; sourceTree = "<group>"; };
 		F4EF380627ADCCF000964191 /* PayloadPersistenceManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayloadPersistenceManagerSpy.swift; sourceTree = "<group>"; };
 		F4FEEF9927D9A1BA00812A6E /* Publishers+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -985,6 +987,7 @@
 			isa = PBXGroup;
 			children = (
 				19ED00962481C3D10033B7BD /* AsyncOperationQueueTests.swift */,
+				F4B987462A0EAA3000421E20 /* AsyncTaskQueueTests.swift */,
 				191F919324C12AAA0050C7C6 /* BackgroundTaskManagerTests.swift */,
 				F417CD3527EBD69F0077210C /* CombineHelperTests.swift */,
 				19ED00942481C3960033B7BD /* DataStructuresTests.swift */,
@@ -2120,6 +2123,7 @@
 				1987FA4C2554AC1A0057F1CC /* EntitySearchTests.swift in Sources */,
 				1987F9D92554A4120057F1CC /* BackgroundTaskManagerTests.swift in Sources */,
 				1987FA322554A5670057F1CC /* CodingPathTests.swift in Sources */,
+				F4B987472A0EAA3000421E20 /* AsyncTaskQueueTests.swift in Sources */,
 				1987FA1A2554A52C0057F1CC /* LRUStoreTests.swift in Sources */,
 				1987F9F62554A4D70057F1CC /* DiskCacheTests.swift in Sources */,
 				1987FA5E2555D9740057F1CC /* CoreManagerContractTests.swift in Sources */,

--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		198A9B6625560DD1008E3C5E /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1987FA452554A7210057F1CC /* Combine.swift */; };
 		198CC31424C663D600E2F951 /* APIClientQueueResponseHandlerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190ADCCE2458D9A500D22F6D /* APIClientQueueResponseHandlerSpy.swift */; };
 		19ED00972481C3D10033B7BD /* AsyncOperationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ED00962481C3D10033B7BD /* AsyncOperationQueueTests.swift */; };
+		F40A55BC2A14197E00612C70 /* CoreManagerPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40A55BB2A14197E00612C70 /* CoreManagerPropertyTests.swift */; };
 		F417CD3127EBD5660077210C /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F417CD3027EBD5660077210C /* Cancellable.swift */; };
 		F417CD3227EBD5660077210C /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F417CD3027EBD5660077210C /* Cancellable.swift */; };
 		F417CD3327EBD5660077210C /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F417CD3027EBD5660077210C /* Cancellable.swift */; };
@@ -735,6 +736,7 @@
 		F405C35024A41844004E1BB3 /* APIClientQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueTests.swift; sourceTree = "<group>"; };
 		F405C35124A41844004E1BB3 /* APIClientQueueDefaultSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueDefaultSchedulerTests.swift; sourceTree = "<group>"; };
 		F405C35224A41844004E1BB3 /* APIClientQueueProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientQueueProcessorTests.swift; sourceTree = "<group>"; };
+		F40A55BB2A14197E00612C70 /* CoreManagerPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreManagerPropertyTests.swift; sourceTree = "<group>"; };
 		F417CD3027EBD5660077210C /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		F417CD3527EBD69F0077210C /* CombineHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineHelperTests.swift; sourceTree = "<group>"; };
 		F438470E27E15D5C00D6EB98 /* CoreManagerProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreManagerProperty.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				F4B987462A0EAA3000421E20 /* AsyncTaskQueueTests.swift */,
 				191F919324C12AAA0050C7C6 /* BackgroundTaskManagerTests.swift */,
 				F417CD3527EBD69F0077210C /* CombineHelperTests.swift */,
+				F40A55BB2A14197E00612C70 /* CoreManagerPropertyTests.swift */,
 				19ED00942481C3960033B7BD /* DataStructuresTests.swift */,
 				190ADC9F2458D8FE00D22F6D /* DiskCacheTests.swift */,
 				190ADC9D2458D8FE00D22F6D /* DiskQueueTests.swift */,
@@ -2145,6 +2148,7 @@
 				1987FA082554A50F0057F1CC /* BaseStoreTests.swift in Sources */,
 				1987FA0E2554A5150057F1CC /* CacheStoreTests.swift in Sources */,
 				1987F9F02554A4C00057F1CC /* DataStructuresTests.swift in Sources */,
+				F40A55BC2A14197E00612C70 /* CoreManagerPropertyTests.swift in Sources */,
 				1987FA2C2554A55A0057F1CC /* RemoteStoreTests.swift in Sources */,
 				19ED00972481C3D10033B7BD /* AsyncOperationQueueTests.swift in Sources */,
 				1987FA582554AC3C0057F1CC /* CoreManagerTests.swift in Sources */,

--- a/Lucid/Utils/Async.swift
+++ b/Lucid/Utils/Async.swift
@@ -40,6 +40,12 @@ fileprivate extension AsyncTasks {
 public extension Task where Success == Void, Failure == any Error {
 
     @discardableResult
+    func storeAsync(in asyncTasks: AsyncTasks) async -> Self {
+        await asyncTasks.append(self)
+        return self
+    }
+
+    @discardableResult
     func store(in asyncTasks: AsyncTasks) -> Self {
         Task {
             await asyncTasks.append(self)
@@ -53,7 +59,7 @@ public extension Task where Success == Void, Failure == any Error {
 public actor AsyncTaskQueue {
 
     private let maxConcurrentTasks: Int
-    private var runningTasks: Int = 0
+    private(set) var runningTasks: Int = 0
     private var queue = [CheckedContinuation<Void, Error>]()
 
     public init(maxConcurrentTasks: Int = 1) {

--- a/Lucid/Utils/AsyncCurrentValue.swift
+++ b/Lucid/Utils/AsyncCurrentValue.swift
@@ -1,0 +1,137 @@
+//
+//  AsyncCurrentValue.swift
+//  Lucid
+//
+//  Created by Stephane Magne on 2023-05-15.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import Foundation
+
+public protocol AsyncCurrentValueDelegate: AnyObject {
+
+    func didRemoveFinalIterator() async
+}
+
+/**
+    This class is meant to replicate Combine.CurrentValueSubject.
+
+    The use case looks like this...
+
+    In the calling class:
+
+        Task {
+            let currentValue = manager.currentValue
+            for await value in currentValue where Task.isCancelled == false {
+                // perform some action
+            }
+        }
+
+     In the class owning AsyncCurrentValue:
+
+        currentValue.update(newValue)
+*/
+public final class AsyncCurrentValue<Element>: AsyncSequence {
+
+    private(set) var value: Element
+
+    private var repository = CurrentValueRepository<Element>()
+
+    public init(_ initialValue: Element) {
+        self.value = initialValue
+    }
+
+    public func makeAsyncIterator() -> CurrentValueIterator<Element> {
+        let iterator = CurrentValueIterator<Element>(value: value)
+        Task {
+            await repository.addIterator(iterator)
+        }
+        return iterator
+    }
+
+    public func update(with updatedValue: Element) {
+        value = updatedValue
+        Task {
+            await repository.update(with: updatedValue)
+        }
+    }
+
+    public func setDelegate(_ delegate: AsyncCurrentValueDelegate) {
+        Task {
+            await repository.setDelegate(delegate)
+        }
+    }
+}
+
+public final actor CurrentValueIterator<Element>: AsyncIteratorProtocol {
+
+    private var value: Element?
+
+    private var valueContinuation: CheckedContinuation<Element, Never>?
+
+    init(value: Element) {
+        self.value = value
+    }
+
+    public func next() async throws -> Element? {
+        if Task.isCancelled {
+            return nil
+        } else if let storedValue = value {
+            value = nil
+            return storedValue
+        } else {
+            return await withCheckedContinuation { continuation in
+                valueContinuation = continuation
+            }
+        }
+    }
+
+    func update(with updatedValue: Element) async {
+        if Task.isCancelled {
+            return
+        } else if let continuation = valueContinuation {
+            valueContinuation = nil
+            continuation.resume(returning: updatedValue)
+        } else {
+            value = updatedValue
+        }
+    }
+}
+
+// MARK: - Private
+
+private final actor CurrentValueRepository<Element> {
+
+    private var iterators: [WeakItem<CurrentValueIterator<Element>>] = []
+
+    private weak var delegate: AsyncCurrentValueDelegate?
+
+    func setDelegate(_ delegate: AsyncCurrentValueDelegate) async {
+        self.delegate = delegate
+    }
+
+    func addIterator(_ iterator: CurrentValueIterator<Element>) async {
+        iterators.append(WeakItem(iterator))
+    }
+
+    func update(with updatedValue: Element) async {
+        let wasPopulated = iterators.isEmpty == false
+        let validIterators = iterators.filter { $0.item != nil }
+        for iterator in iterators {
+            await iterator.item?.update(with: updatedValue)
+        }
+        iterators = validIterators
+        if iterators.isEmpty && wasPopulated {
+            await delegate?.didRemoveFinalIterator()
+        }
+    }
+}
+
+private class WeakItem<T: AnyObject> {
+
+    weak var item: T?
+
+    init(_ item: T) {
+        self.item = item
+    }
+}

--- a/Lucid/Utils/CoreManagerProperty.swift
+++ b/Lucid/Utils/CoreManagerProperty.swift
@@ -9,57 +9,102 @@
 import Combine
 import Foundation
 
-final class CoreManagerProperty<Output: Equatable>: Publisher {
+final actor CoreManagerProperty<Output: Equatable> {
 
-    typealias Failure = Never
+    let stream = AsyncCurrentValue<Output?>(nil)
 
-    private let currentValue = CurrentValueSubject<Output?, Failure>(nil)
+    var value: Output? {
+        return stream.value
+    }
+
+    init() {
+        stream.setDelegate(self)
+    }
 
     // CoreManager
 
-    var willAddFirstObserver: (() -> Void)?
+    private var didRemoveLastObserver: (() async -> Void)?
 
-    var willRemoveLastObserver: (() -> Void)?
-
-    private let dataLock = NSRecursiveLock(name: "\(CoreManagerProperty.self):data_lock")
-
-    private var observerCount = 0
-
-    // Init
-
-    var value: Output? {
-        dataLock.lock()
-        defer { dataLock.unlock() }
-
-        return currentValue.value
+    func setDidRemoveLastObserver(_ block: @escaping () async -> Void) async {
+        didRemoveLastObserver = block
     }
 
-    func update(with value: Output) {
-        dataLock.lock()
-        defer { dataLock.unlock() }
+    func update(with value: Output) async {
+        guard self.stream.value != value else { return }
+        stream.update(with: value)
+    }
+}
 
-        guard self.currentValue.value != value else { return }
-        self.currentValue.value = value
+// MARK: - AsyncCurrentValueDelegate
+
+extension CoreManagerProperty: AsyncCurrentValueDelegate {
+
+    func didRemoveFinalIterator() async {
+        await didRemoveLastObserver?()
+    }
+}
+
+// MARK: - Combine helper to transpose async signals to Publishers
+
+final class CoreManagerAsyncToCombineProperty<Output: Equatable, Failure: Error> {
+
+    private let currentValue = CurrentValueSubject<Output?, Failure>(nil)
+
+    private let continuousCurrentValue = CurrentValueSubject<Output?, Failure>(nil)
+
+    private let cancellable = CancellableBox()
+
+    // Swift Concurrency
+
+    private let signals: Task<(once: Output, continuous: AsyncStream<Output>), Error>
+
+    var once: CoreManagerCombineProperty<Output, Failure> {
+        return CoreManagerCombineProperty<Output, Failure>(signals, type: .once)
+    }
+
+    var continuous: AnySafePublisher<Output> {
+        return CoreManagerCombineProperty<Output, Failure>(signals, type: .continuous).suppressError()
+    }
+
+    init(_ signalFunction: @escaping () async throws -> (once: Output, continuous: AsyncStream<Output>)) {
+        self.signals = Task {
+            return try await signalFunction()
+        }
+    }
+}
+
+final class CoreManagerCombineProperty<Output: Equatable, Failure: Error>: Publisher {
+
+    enum PublisherType {
+        case once
+        case continuous
+    }
+
+    private let currentValue = CurrentValueSubject<Output?, Failure>(nil)
+
+    private let isFirstSubscriber = PropertyBox<Bool>(false, atomic: true)
+
+    // Swift Concurrency
+
+    private let signals: Task<(once: Output, continuous: AsyncStream<Output>), Error>
+
+    private let type: PublisherType
+
+    private let asyncTasks = AsyncTasks()
+
+    init(_ signals: Task<(once: Output, continuous: AsyncStream<Output>), Error>, type: PublisherType) {
+        self.signals = signals
+        self.type = type
     }
 
     // MARK: Publisher
 
     public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
-        dataLock.lock()
-        defer { dataLock.unlock() }
 
-        self.observerCount += 1
-        if self.observerCount == 1 {
-            self.willAddFirstObserver?()
-        }
-
-        let subscription = CoreManagerSubscription<S>(subscriber) {
-            self.dataLock.lock()
-            defer { self.dataLock.unlock() }
-
-            self.observerCount -= 1
-            if self.observerCount == 0 {
-                self.willRemoveLastObserver?()
+        let subscription = CoreManagerSubscription<S>(subscriber) { [weak self] in
+            guard let self = self else { return }
+            Task {
+                await self.asyncTasks.cancel()
             }
         }
 
@@ -67,16 +112,49 @@ final class CoreManagerProperty<Output: Equatable>: Publisher {
 
         subscription.cancellable = currentValue
             .compactMap { $0 }
-            .sink(receiveValue: { [weak self] value in
+            .sink(receiveCompletion: { [weak self] terminal in
                 guard self != nil else { return }
+                subscriber.receive(completion: terminal)
+            }, receiveValue: { [weak self] value in
+                guard let self = self else { return }
                 _ = subscriber.receive(value)
+                switch self.type {
+                case .once:
+                    subscriber.receive(completion: .finished)
+                case .continuous:
+                    return
+                }
             })
+
+        if isFirstSubscriber.value == false {
+            isFirstSubscriber.value = true
+
+            Task {
+                do {
+                    switch self.type {
+                    case .once:
+                        let result = try await signals.value.once
+                        self.currentValue.send(result)
+                        self.currentValue.send(completion: .finished)
+
+                    case .continuous:
+                        Task {
+                            for await value in try await signals.value.continuous where Task.isCancelled == false {
+                                self.currentValue.send(value)
+                            }
+                        }.store(in: self.asyncTasks)
+                    }
+                } catch let error as Failure {
+                    self.currentValue.send(completion: .failure(error))
+                }
+            }.store(in: asyncTasks)
+        }
     }
 }
 
 // MARK: - Subscription
 
-private extension CoreManagerProperty {
+private extension CoreManagerCombineProperty {
 
     final class CoreManagerSubscription<S: Subscriber>: Subscription where S.Input == Output, S.Failure == Failure {
 

--- a/LucidTestKit/Doubles/CoreManagerSpy.swift
+++ b/LucidTestKit/Doubles/CoreManagerSpy.swift
@@ -72,15 +72,15 @@ public final class CoreManagerSpy<E: Entity> {
     )]?
 
     public var searchAsyncStub: (
-        once: () async throws -> QueryResult<E>,
+        once: QueryResult<E>,
         continuous: AsyncStream<QueryResult<E>>
     ) = (
-        once: { throw ManagerError.notSupported },
+        once: QueryResult<E>.entities([]),
         continuous: AsyncStream<QueryResult<E>>(unfolding: { return nil })
     )
 
     public var searchAsyncStubs: [(
-        once: () async throws -> QueryResult<E>,
+        once: QueryResult<E>,
         continuous: AsyncStream<QueryResult<E>>
     )]?
 
@@ -138,7 +138,7 @@ public final class CoreManagerSpy<E: Entity> {
     }
 
     public func search(withQuery query: Query<E>,
-                       in context: ReadContext<E>) async throws -> (once: () async throws -> QueryResult<E>, continuous: AsyncStream<QueryResult<E>>) {
+                       in context: ReadContext<E>) async throws -> (once: QueryResult<E>, continuous: AsyncStream<QueryResult<E>>) {
         searchAsyncRecords.append(SearchRecord(query: query, context: context))
         return searchAsyncStubs?.getOrFail(at: searchAsyncRecords.count - 1) ?? searchAsyncStub
     }

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -4366,13 +4366,13 @@ final class CoreManagerTests: XCTestCase {
         do {
             let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
 
-            Task {
+            await Task {
                 _ = try? await signals.once()
 
                 for await _ in signals.continuous {
                     continuousExpectation.fulfill()
                 }
-            }.store(in: asyncTasks)
+            }.storeAsync(in: asyncTasks)
 
             await asyncTasks.cancel()
 
@@ -4405,11 +4405,11 @@ final class CoreManagerTests: XCTestCase {
         do {
             let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
 
-            Task {
+            await Task {
                 _ = try await signals.once()
 
                 onceExpectation.fulfill()
-            }.store(in: asyncTasks)
+            }.storeAsync(in: asyncTasks)
 
             await asyncTasks.cancel()
 
@@ -4441,11 +4441,10 @@ final class CoreManagerTests: XCTestCase {
         )
 
 
-        Task {
+        await Task {
             _ = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
-
             onceExpectation.fulfill()
-        }.store(in: asyncTasks)
+        }.storeAsync(in: asyncTasks)
 
         await asyncTasks.cancel()
 
@@ -4465,10 +4464,10 @@ final class CoreManagerTests: XCTestCase {
         let onceExpectation = self.expectation(description: "once")
         onceExpectation.isInverted = true
 
-        Task {
+        await Task {
             _ = try await manager.set(entity, in: WriteContext(dataTarget: .local))
             onceExpectation.fulfill()
-        }.store(in: asyncTasks)
+        }.storeAsync(in: asyncTasks)
 
         await asyncTasks.cancel()
 

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -1035,7 +1035,7 @@ final class CoreManagerTests: XCTestCase {
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 2)
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
@@ -1062,7 +1062,7 @@ final class CoreManagerTests: XCTestCase {
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 2)
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
@@ -1093,11 +1093,19 @@ final class CoreManagerTests: XCTestCase {
                 group.addTask {
                     let stream = try await self.manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).continuous
 
+                    var continuousCallCount = 0
+
                     for await result in stream {
-                        XCTAssertEqual(result.count, 2)
-                        XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
-                        XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
-                        return
+                        if continuousCallCount == 0 {
+                            XCTAssertEqual(result.count, 1)
+                            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+                        } else {
+                            XCTAssertEqual(result.count, 2)
+                            XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
+                            XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 43)
+                            return
+                        }
+                        continuousCallCount += 1
                     }
                 }
 
@@ -1530,9 +1538,9 @@ final class CoreManagerTests: XCTestCase {
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                     XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
-                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
-                    XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
-                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+                    XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 3)
+                    XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 4)
+                    XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 2)
                     onceExpectation.fulfill()
                 }
             })
@@ -1555,7 +1563,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1582,7 +1590,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1611,7 +1619,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTFail("Unexpected result: \(result)")
         } catch let error as ManagerError where error == .store(.composite(current: .notSupported, previous: .api(.api(httpStatusCode: 500, errorPayload: nil, response: response)))) {
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
@@ -1634,7 +1642,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTFail("Unexpected result: \(result)")
         } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
@@ -1654,7 +1662,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1679,7 +1687,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1706,7 +1714,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTFail("Unexpected result: \(result)")
         } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
@@ -1722,7 +1730,7 @@ final class CoreManagerTests: XCTestCase {
         let context = ReadContext<EntitySpy>(dataSource: .local)
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1748,7 +1756,7 @@ final class CoreManagerTests: XCTestCase {
         )))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1777,7 +1785,7 @@ final class CoreManagerTests: XCTestCase {
         )))
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertEqual(result.first?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
@@ -1785,9 +1793,9 @@ final class CoreManagerTests: XCTestCase {
             try? await Task.sleep(nanoseconds: 50000)
 
             XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
-            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
-            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
+            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 3)
+            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 4)
+            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 2)
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -1861,6 +1869,7 @@ final class CoreManagerTests: XCTestCase {
             .store(in: &cancellables)
 
         wait(for: [onceExpectation, continuousExpectation], timeout: 1)
+//        wait(for: [onceExpectation], timeout: 1)
     }
 
     func test_manager_should_send_entity_update_to_provider_when_entity_changed() {
@@ -2483,11 +2492,12 @@ final class CoreManagerTests: XCTestCase {
         )))
 
         do {
-            let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
-
             try await withThrowingTaskGroup(of: Void.self) { group in
+
+                let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
+
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2541,7 +2551,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2601,7 +2611,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2653,7 +2663,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2714,7 +2724,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2773,7 +2783,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2825,7 +2835,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2888,7 +2898,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -2945,7 +2955,7 @@ final class CoreManagerTests: XCTestCase {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
@@ -3287,6 +3297,8 @@ final class CoreManagerTests: XCTestCase {
 
                     for await result in allQuerySignals.continuous {
                         if continuousCallCount == 0 {
+                            XCTAssertEqual(result.count, 0)
+                        } else if continuousCallCount == 1 {
                             XCTAssertEqual(result.first?.title, "fake_title")
                             XCTAssertEqual(result.count, 1)
                         } else {
@@ -3311,7 +3323,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once
                     XCTAssertEqual(result.first?.title, "fake_title")
                 }
 
@@ -3330,7 +3342,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once
                     XCTAssertEqual(result.first?.title, "another_fake_title")
                 }
 
@@ -3349,6 +3361,7 @@ final class CoreManagerTests: XCTestCase {
         do {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 // Continuous Listener
+
                 group.addTask {
                     var continuousCallCount = 0
 
@@ -3357,6 +3370,8 @@ final class CoreManagerTests: XCTestCase {
 
                     for await result in allQuerySignals.continuous {
                         if continuousCallCount == 0 {
+                            XCTAssertTrue(result.isEmpty)
+                        } else if continuousCallCount == 1 {
                             XCTAssertEqual(result.first?.title, "fake_title")
                             XCTAssertEqual(result.count, 1)
                         } else {
@@ -3371,6 +3386,8 @@ final class CoreManagerTests: XCTestCase {
                 }
                 // First Update
                 group.addTask {
+                    try await Task.sleep(nanoseconds: 10000)
+
                     self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
                     self.memoryStoreSpy.searchResultStub = .success(.entities([]))
                     self.memoryStoreSpy.setResultStub = .success([EntitySpy(idValue: .remote(42, nil), title: "fake_title")])
@@ -3382,13 +3399,13 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once
                     XCTAssertEqual(result.first?.title, "fake_title")
                 }
 
                 // Second Update
                 group.addTask {
-                    try await Task.sleep(nanoseconds: 10000)
+                    try await Task.sleep(nanoseconds: 20000)
 
                     self.remoteStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(43, nil), title: "another_fake_title")]))
                     self.memoryStoreSpy.searchResultStub = .success(.entities([EntitySpy(idValue: .remote(42, nil), title: "fake_title")]))
@@ -3401,7 +3418,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once
                     XCTAssertEqual(result.first?.title, "another_fake_title")
                 }
 
@@ -3428,6 +3445,8 @@ final class CoreManagerTests: XCTestCase {
 
                     for await result in allQuerySignals.continuous {
                         if continuousCallCount == 0 {
+                            XCTAssertTrue(result.isEmpty)
+                        } else if continuousCallCount == 1 {
                             XCTAssertEqual(result.first?.title, "fake_title")
                             XCTAssertEqual(result.count, 1)
                         } else {
@@ -3458,7 +3477,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: firstContext).once
                     XCTAssertEqual(result.first?.title, "fake_title")
                 }
 
@@ -3481,7 +3500,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    let result = try await self.manager.search(withQuery: .all, in: secondContext).once
                     XCTAssertEqual(result.first?.title, "another_fake_title")
                 }
 
@@ -3682,7 +3701,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            _ = try await manager.search(withQuery: .all, in: context).once()
+            _ = try await manager.search(withQuery: .all, in: context).once
 
             XCTAssertEqual(memoryStoreSpy.removeCallCount, 1)
             XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 3)
@@ -3718,7 +3737,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            _ = try await manager.search(withQuery: .all, in: context).once()
+            _ = try await manager.search(withQuery: .all, in: context).once
 
             XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
             XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
@@ -3752,7 +3771,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            _ = try await manager.search(withQuery: .all, in: context).once()
+            _ = try await manager.search(withQuery: .all, in: context).once
 
             XCTAssertEqual(memoryStoreSpy.removeCallCount, 0)
             XCTAssertEqual(memoryStoreSpy.identifierRecords.count, 0)
@@ -4034,16 +4053,23 @@ final class CoreManagerTests: XCTestCase {
                 group.addTask {
                     let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
 
+                    var continuousCount = 0
+
                     for await result in continuous {
-                        guard result.count == 3 else {
-                            XCTFail("Expected 3 entities")
+                        if continuousCount == 0 {
+                            XCTAssertTrue(result.isEmpty)
+                        } else {
+                            guard result.count == 3 else {
+                                XCTFail("Expected 3 entities")
+                                return
+                            }
+
+                            XCTAssertEqual(result.array[0].title, "another_fake_title")
+                            XCTAssertEqual(result.array[1].title, "fake_title")
+                            XCTAssertEqual(result.array[2].title, "some_fake_title")
                             return
                         }
-
-                        XCTAssertEqual(result.array[0].title, "another_fake_title")
-                        XCTAssertEqual(result.array[1].title, "fake_title")
-                        XCTAssertEqual(result.array[2].title, "some_fake_title")
-                        return
+                        continuousCount += 1
                     }
                 }
 
@@ -4064,7 +4090,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once
                 }
 
                 try await group.waitForAll()
@@ -4090,16 +4116,23 @@ final class CoreManagerTests: XCTestCase {
                     let firstContext = ReadContext<EntitySpy>(dataSource: .local)
                     let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
 
+                    var continuousCount = 0
+
                     for await result in continuous {
-                        guard result.count == 3 else {
-                            XCTFail("Expected 3 entities")
+                        if continuousCount == 0 {
+                            XCTAssertTrue(result.isEmpty)
+                        } else {
+                            guard result.count == 3 else {
+                                XCTFail("Expected 3 entities")
+                                return
+                            }
+
+                            XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+                            XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
+                            XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
                             return
                         }
-
-                        XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
-                        XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
-                        XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
-                        return
+                        continuousCount += 1
                     }
                 }
 
@@ -4120,7 +4153,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once
                 }
 
                 try await group.waitForAll()
@@ -4146,16 +4179,23 @@ final class CoreManagerTests: XCTestCase {
                     let firstContext = ReadContext<EntitySpy>(dataSource: .local)
                     let continuous = try await self.manager.search(withQuery: query, in: firstContext).continuous
 
+                    var continuousCount = 0
+
                     for await result in continuous {
-                        guard result.count == 3 else {
-                            XCTFail("Expected 3 entities")
+                        if continuousCount == 0 {
+                            XCTAssertTrue(result.isEmpty)
+                        } else {
+                            guard result.count == 3 else {
+                                XCTFail("Expected 3 entities")
+                                return
+                            }
+
+                            XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
+                            XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
+                            XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
                             return
                         }
-
-                        XCTAssertEqual(result.array[0].identifier, EntitySpyIdentifier(value: .remote(43, nil)))
-                        XCTAssertEqual(result.array[1].identifier, EntitySpyIdentifier(value: .remote(44, nil)))
-                        XCTAssertEqual(result.array[2].identifier, EntitySpyIdentifier(value: .remote(42, nil)))
-                        return
+                        continuousCount += 1
                     }
                 }
 
@@ -4176,7 +4216,7 @@ final class CoreManagerTests: XCTestCase {
                         )
                     )
 
-                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once()
+                    _ = try await self.manager.search(withQuery: .all, in: secondContext).once
                 }
 
                 try await group.waitForAll()
@@ -4204,7 +4244,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            let result = try await manager.search(withQuery: .all, in: secondContext).once()
+            let result = try await manager.search(withQuery: .all, in: secondContext).once
 
             XCTAssertEqual(result.map { $0.title }, [
                 "fake_title",
@@ -4367,7 +4407,7 @@ final class CoreManagerTests: XCTestCase {
             let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
 
             await Task {
-                _ = try? await signals.once()
+                _ = signals.once
 
                 for await _ in signals.continuous {
                     continuousExpectation.fulfill()
@@ -4406,7 +4446,7 @@ final class CoreManagerTests: XCTestCase {
             let signals = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context)
 
             await Task {
-                _ = try await signals.once()
+                _ = signals.once
 
                 onceExpectation.fulfill()
             }.storeAsync(in: asyncTasks)
@@ -4492,8 +4532,9 @@ final class CoreManagerTests: XCTestCase {
 
         let context = ReadContext<EntitySpy>(dataSource: .local)
 
-        manager
-            .search(withQuery: .all, in: context)
+        let search = manager.search(withQuery: .all, in: context)
+
+        search
             .continuous
             .sink { result in
                 guard continuousCallCount < count else {
@@ -4546,7 +4587,6 @@ final class CoreManagerTests: XCTestCase {
                 group.addTask {
                     var continuousCallCount = 0
                     let signals = try await self.manager.search(withQuery: .all, in: context)
-                    _ = try await signals.once()
                     for await result in signals.continuous {
                         guard continuousCallCount < count else {
                             XCTFail("received too many responses")
@@ -4831,7 +4871,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .all, in: context).once()
+            let result = try await manager.search(withQuery: .all, in: context).once
             XCTAssertNotNil(result.metadata)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -4852,7 +4892,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.search(withQuery: .all, in: context).once()
+            let result = try await manager.search(withQuery: .all, in: context).once
             XCTAssertNotNil(result.metadata)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -4873,7 +4913,7 @@ final class CoreManagerTests: XCTestCase {
         )))
 
         do {
-            let result = try await manager.search(withQuery: .all, in: context).once()
+            let result = try await manager.search(withQuery: .all, in: context).once
             XCTAssertNotNil(result.metadata)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -4968,7 +5008,7 @@ final class CoreManagerTests: XCTestCase {
         ))
 
         do {
-            let result = try await manager.get(byIDs: [EntitySpyIdentifier(value: .remote(42, nil))], in: context).once()
+            let result = try await manager.get(byIDs: [EntitySpyIdentifier(value: .remote(42, nil))], in: context).once
             XCTAssertNotNil(result.metadata)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -5459,7 +5499,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once Update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
                     XCTAssertEqual(result.first?.lazy, .unrequested)
                     XCTAssertEqual(result.count, 1)
 
@@ -5511,7 +5551,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.lazy, .requested(6))
                     XCTAssertEqual(result.count, 1)
@@ -5563,7 +5603,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.lazy, .requested(6))
                     XCTAssertEqual(result.count, 1)
@@ -5623,7 +5663,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.lazy, .unrequested)
                     XCTAssertEqual(result.count, 1)
@@ -5683,7 +5723,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.first?.lazy, .requested(7))
                     XCTAssertEqual(result.count, 1)
@@ -5938,20 +5978,20 @@ final class CoreManagerTests: XCTestCase {
             })
             .store(in: &cancellables)
 
-            publishers
-                .continuous
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .failure(let error):
-                        XCTFail("Unexpected error: \(error)")
-                    case .finished:
-                        XCTFail("Unexpected completion.")
-                    }
-                }, receiveValue: { result in
-                    XCTAssertEqual(result.count, 1)
-                    continuousExpectation.fulfill()
-                })
-                .store(in: &cancellables)
+        publishers
+            .continuous
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTFail("Unexpected error: \(error)")
+                case .finished:
+                    XCTFail("Unexpected completion.")
+                }
+            }, receiveValue: { result in
+                XCTAssertEqual(result.count, 1)
+                continuousExpectation.fulfill()
+            })
+            .store(in: &cancellables)
 
         wait(for: [onceExpectation, continuousExpectation], timeout: 1)
     }
@@ -6009,7 +6049,7 @@ final class CoreManagerTests: XCTestCase {
             })
             .store(in: &cancellables)
 
-        wait(for: [onceExpectation], timeout: 1)
+        wait(for: [onceExpectation], timeout: 5)
     }
 
     func test_user_access_validation_set_returns_remote_response_for_remote_access_level() {
@@ -6661,7 +6701,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once Update
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.count, 1)
                     XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
@@ -6708,7 +6748,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
 
                     XCTAssertEqual(result.count, 1)
                     XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 0)
@@ -6758,7 +6798,7 @@ final class CoreManagerTests: XCTestCase {
 
                 // Once
                 group.addTask {
-                    let result = try await signals.once()
+                    let result = signals.once
                     XCTFail("Unexpected value: \(result)")
                 }
 
@@ -7484,7 +7524,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTFail("Unexpected result: \(result)")
         } catch let error as ManagerError {
             XCTAssertEqual(error, .userAccessInvalid)
@@ -8245,7 +8285,7 @@ final class CoreManagerTests: XCTestCase {
             let result = try await manager.search(
                 withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))),
                 in: context
-            ).once()
+            ).once
 
             XCTAssertTrue(result.isEmpty)
         } catch {
@@ -8273,7 +8313,7 @@ final class CoreManagerTests: XCTestCase {
             let result = try await manager.search(
                 withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))),
                 in: context
-            ).once()
+            ).once
 
             XCTAssertTrue(result.isEmpty)
         } catch {
@@ -8300,7 +8340,7 @@ final class CoreManagerTests: XCTestCase {
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
         } catch {
@@ -8327,7 +8367,7 @@ final class CoreManagerTests: XCTestCase {
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
         } catch {
@@ -8352,7 +8392,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertTrue(result.isEmpty)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -8376,7 +8416,7 @@ final class CoreManagerTests: XCTestCase {
         )
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil)))), in: context).once
             XCTAssertTrue(result.isEmpty)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -8402,7 +8442,7 @@ final class CoreManagerTests: XCTestCase {
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
 
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
         } catch {
@@ -8428,7 +8468,7 @@ final class CoreManagerTests: XCTestCase {
 
         let expectedIdentifiers = [EntitySpyIdentifier(value: .remote(42, nil)), EntitySpyIdentifier(value: .remote(43, nil))]
         do {
-            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once()
+            let result = try await manager.search(withQuery: .filter(.identifier >> expectedIdentifiers), in: context).once
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result.first?.identifier, EntitySpyIdentifier(value: .remote(43, nil)))
         } catch {

--- a/LucidTests/Utils/AsyncCurrentValueTests.swift
+++ b/LucidTests/Utils/AsyncCurrentValueTests.swift
@@ -1,0 +1,196 @@
+//
+//  AsyncCurrentValueTests.swift
+//  LucidTests
+//
+//  Created by Stephane Magne on 2023-05-16.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import XCTest
+@testable import Lucid
+
+final class AsyncCurrentValueTests: XCTestCase {
+
+    private var continuousCount: Int!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        continuousCount = 0
+    }
+
+    override func tearDown() async throws {
+        continuousCount = nil
+        try await super.tearDown()
+    }
+
+    // MARK: Adding to empty queue
+
+    func test_that_observer_gets_initial_value() async {
+
+        let currentValue = AsyncCurrentValue(5)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for try await value in currentValue {
+                        XCTAssertEqual(value, 5)
+                        return
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_observer_gets_initial_value_and_following_values() async {
+
+        let currentValue = AsyncCurrentValue(5)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for try await value in currentValue {
+                        if self.continuousCount == 0 {
+                            XCTAssertEqual(value, 5)
+                        } else if self.continuousCount == 1 {
+                            XCTAssertEqual(value, 10)
+                        } else if self.continuousCount == 2 {
+                            XCTAssertEqual(value, 12)
+                            return
+                        }
+                        self.continuousCount += 1
+                    }
+                }
+
+                group.addTask {
+                    currentValue.update(with: 10)
+                    currentValue.update(with: 12)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_new_observer_gets_the_most_recent_value() async {
+
+        let currentValue = AsyncCurrentValue(5)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    currentValue.update(with: 10)
+                }
+
+                group.addTask {
+                    for try await value in currentValue {
+                        XCTAssertEqual(value, 10)
+                        return
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_new_observer_gets_the_most_recent_value_and_following_values() async {
+
+        let currentValue = AsyncCurrentValue(5)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    currentValue.update(with: 10)
+                }
+
+                group.addTask {
+                    for try await value in currentValue {
+                        if self.continuousCount == 0 {
+                            XCTAssertEqual(value, 10)
+                        } else if self.continuousCount == 1 {
+                            XCTAssertEqual(value, 20)
+                        } else if self.continuousCount == 2 {
+                            XCTAssertEqual(value, 115)
+                            return
+                        }
+                        self.continuousCount += 1
+                    }
+                }
+
+                group.addTask {
+                    currentValue.update(with: 20)
+                    currentValue.update(with: 115)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_all_observers_receive_values() async {
+
+        let currentValue = AsyncCurrentValue(5)
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+
+                group.addTask {
+                    var count = 0
+                    for try await value in currentValue {
+                        if count == 0 {
+                            XCTAssertEqual(value, 5)
+                        } else if count == 1 {
+                            XCTAssertEqual(value, 22)
+                            return
+                        }
+                        count += 1
+                    }
+                }
+
+                group.addTask {
+                    var count = 0
+                    for try await value in currentValue {
+                        if count == 0 {
+                            XCTAssertEqual(value, 5)
+                        } else if count == 1 {
+                            XCTAssertEqual(value, 22)
+                            return
+                        }
+                        count += 1
+                    }
+                }
+
+                group.addTask {
+                    var count = 0
+                    for try await value in currentValue {
+                        if count == 0 {
+                            XCTAssertEqual(value, 5)
+                        } else if count == 1 {
+                            XCTAssertEqual(value, 22)
+                            return
+                        }
+                        count += 1
+                    }
+                }
+
+                group.addTask {
+                    currentValue.update(with: 22)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/LucidTests/Utils/AsyncTaskQueueTests.swift
+++ b/LucidTests/Utils/AsyncTaskQueueTests.swift
@@ -1,0 +1,316 @@
+//
+//  AsyncTaskQueueTests.swift
+//  LucidTests
+//
+//  Created by Stephane Magne on 2023-05-12.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import XCTest
+@testable import Lucid
+
+final class AsyncTaskQueueTests: XCTestCase {
+
+    // MARK: Adding to empty queue
+
+    func test_that_it_immediately_runs_a_concurrent_operation_added_to_an_empty_queue() {
+
+        let asyncTaskQueue = AsyncTaskQueue(maxConcurrentTasks: 1)
+        let operation = BlockingOperation()
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation.setUp()
+                    await operation.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        let setUpExpectation = expectation(description: "set_up_expectation")
+
+        Task { @MainActor in
+            await operation.waitForSetUp()
+
+            let hasStarted = await operation.hasStarted
+            let runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(hasStarted)
+            XCTAssertEqual(runningTasks, 1)
+
+            await operation.resume()
+            setUpExpectation.fulfill()
+        }
+
+        wait(for: [setUpExpectation], timeout: 1)
+    }
+
+    func test_that_it_decrements_the_running_tasks_after_completion() {
+
+        let asyncTaskQueue = AsyncTaskQueue(maxConcurrentTasks: 1)
+        let operation = BlockingOperation()
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation.setUp()
+                    await operation.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        let setUpExpectation = expectation(description: "set_up_expectation")
+
+        Task { @MainActor in
+            await operation.waitForSetUp()
+
+            let hasStarted = await operation.hasStarted
+            var runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(hasStarted)
+            XCTAssertEqual(runningTasks, 1)
+
+            await operation.resume()
+            try? await Task.sleep(nanoseconds: 1000)
+
+            let hasCompleted = await operation.hasCompleted
+            runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(hasCompleted)
+            XCTAssertEqual(runningTasks, 0)
+
+            setUpExpectation.fulfill()
+        }
+
+        wait(for: [setUpExpectation], timeout: 1)
+    }
+
+    // MARK: Adding to populated queue
+
+    func test_that_it_does_not_immediately_runs_a_concurrent_operation_added_to_queue_at_capacity() {
+
+        let asyncTaskQueue = AsyncTaskQueue(maxConcurrentTasks: 1)
+
+        let operation1 = BlockingOperation()
+        let operation2 = BlockingOperation()
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation1.setUp()
+                    await operation1.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation2.setUp()
+                    await operation2.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        let setUpExpectation = expectation(description: "set_up_expectation")
+
+        Task { @MainActor in
+            await operation1.waitForSetUp()
+            try? await Task.sleep(nanoseconds: 1000)
+            let operation1HasStarted = await operation1.hasStarted
+            let operation2HasStarted = await operation2.hasStarted
+            let runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(operation1HasStarted)
+            XCTAssertFalse(operation2HasStarted)
+            XCTAssertEqual(runningTasks, 1)
+
+            await operation1.resume()
+            await operation2.resume()
+
+            setUpExpectation.fulfill()
+        }
+
+        wait(for: [setUpExpectation], timeout: 1)
+    }
+
+    func test_that_it_immediately_runs_a_concurrent_operation_added_to_queue_not_at_capacity() {
+
+        let asyncTaskQueue = AsyncTaskQueue(maxConcurrentTasks: 2)
+
+        let operation1 = BlockingOperation()
+        let operation2 = BlockingOperation()
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation1.setUp()
+                    await operation1.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation2.setUp()
+                    await operation2.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        let setUpExpectation = expectation(description: "set_up_expectation")
+
+        Task { @MainActor in
+            await operation1.waitForSetUp()
+            await operation2.waitForSetUp()
+
+            let operation1HasStarted = await operation1.hasStarted
+            let operation2HasStarted = await operation2.hasStarted
+            let runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(operation1HasStarted)
+            XCTAssertTrue(operation2HasStarted)
+            XCTAssertEqual(runningTasks, 2)
+
+            await operation1.resume()
+            await operation2.resume()
+
+            setUpExpectation.fulfill()
+        }
+
+        wait(for: [setUpExpectation], timeout: 1)
+    }
+
+    func test_that_it_immediately_starts_the_next_time_after_an_operation_has_completed() {
+
+        let asyncTaskQueue = AsyncTaskQueue(maxConcurrentTasks: 2)
+
+        let operation1 = BlockingOperation()
+        let operation2 = BlockingOperation()
+        let operation3 = BlockingOperation()
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation1.setUp()
+                    await operation1.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation2.setUp()
+                    await operation2.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        Task {
+            do {
+                try await asyncTaskQueue.enqueue(operation: {
+                    await operation3.setUp()
+                    await operation3.perform()
+                })
+            } catch {
+                XCTFail("unexpected error thrown: \(error)")
+            }
+        }
+
+        let setUpExpectation = expectation(description: "set_up_expectation")
+
+        Task { @MainActor in
+            await operation1.waitForSetUp()
+            await operation2.waitForSetUp()
+            try? await Task.sleep(nanoseconds: 1000)
+
+            let operation1HasStarted = await operation1.hasStarted
+            let operation2HasStarted = await operation2.hasStarted
+            var operation3HasStarted = await operation3.hasStarted
+            var runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(operation1HasStarted)
+            XCTAssertTrue(operation2HasStarted)
+            XCTAssertFalse(operation3HasStarted)
+            XCTAssertEqual(runningTasks, 2)
+
+            await operation1.resume()
+            await operation3.waitForSetUp()
+
+            let operation1HasCompleted = await operation1.hasCompleted
+            let operation2HasCompleted = await operation2.hasCompleted
+            operation3HasStarted = await operation3.hasStarted
+            runningTasks = await asyncTaskQueue.runningTasks
+
+            XCTAssertTrue(operation1HasCompleted)
+            XCTAssertFalse(operation2HasCompleted)
+            XCTAssertTrue(operation3HasStarted)
+            XCTAssertEqual(runningTasks, 2)
+
+            setUpExpectation.fulfill()
+        }
+
+        wait(for: [setUpExpectation], timeout: 1)
+    }
+}
+
+private final actor BlockingOperation {
+
+    private(set) var hasStarted: Bool = false
+
+    private(set) var hasCompleted: Bool = false
+
+    private var performContinuation: CheckedContinuation<Void, Never>?
+
+    private var setUpObserverContinuation: CheckedContinuation<Void, Never>?
+
+    func setUp() async {
+        await withCheckedContinuation { continuation in
+            hasStarted = true
+            continuation.resume()
+            if let setUpObserverContinuation = self.setUpObserverContinuation {
+                setUpObserverContinuation.resume()
+            }
+        }
+    }
+
+    func waitForSetUp() async {
+        await withCheckedContinuation { continuation in
+            if self.hasStarted {
+                continuation.resume()
+                return
+            }
+            self.setUpObserverContinuation = continuation
+        }
+    }
+
+    func perform() async {
+        await withCheckedContinuation { continuation in
+            self.performContinuation = continuation
+        }
+    }
+
+    func resume() async {
+        guard let performContinuation = performContinuation else { return }
+        hasCompleted = true
+        performContinuation.resume()
+    }
+}

--- a/LucidTests/Utils/CoreManagerPropertyTests.swift
+++ b/LucidTests/Utils/CoreManagerPropertyTests.swift
@@ -6,4 +6,153 @@
 //  Copyright © 2023 Scribd. All rights reserved.
 //
 
-import Foundation
+import XCTest
+@testable import Lucid
+
+final class CoreManagerPropertyTests: XCTestCase {
+
+    // MARK: Adding to empty queue
+
+    func test_that_observer_gets_initial_value() async {
+
+        let property = CoreManagerProperty<Int>()
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await property.update(with: 5)
+                }
+
+                group.addTask {
+                    for try await value in await property.stream {
+                        XCTAssertEqual(value, 5)
+                        return
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_observer_gets_update() async {
+
+        let property = CoreManagerProperty<Int>()
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    var count = 0
+                    for try await value in await property.stream {
+                        if count == 0 {
+                            XCTAssertEqual(value, nil)
+                        } else if count == 1 {
+                            XCTAssertEqual(value, 5)
+                            return
+                        }
+                        count += 1
+                    }
+                }
+
+                group.addTask {
+                    await property.update(with: 5)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_observer_does_not_get_update_for_duplicate_values() async {
+
+        let property = CoreManagerProperty<Int>()
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    var count = 0
+                    for try await value in await property.stream {
+                        if count == 0 {
+                            XCTAssertEqual(value, nil)
+                        } else if count == 1 {
+                            XCTAssertEqual(value, 5)
+                        } else if count == 2 {
+                            XCTAssertEqual(value, 17)
+                            return
+                        }
+                        count += 1
+                    }
+                }
+
+                group.addTask {
+                    await property.update(with: 5)
+                    await property.update(with: 5)
+                    await property.update(with: 17)
+                }
+
+                try await group.waitForAll()
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_that_delegate_gets_called_when_observers_are_released() {
+
+        let property = CoreManagerProperty<Int>()
+        let delegateExpectation = self.expectation(description: "delegate_called_expectation")
+        let asyncTasks = AsyncTasks()
+
+
+        Task {
+            await property.setDidRemoveLastObserver {
+                delegateExpectation.fulfill()
+            }
+        }
+
+        Task {
+            var count = 0
+            for try await value in await property.stream {
+                if count == 0 {
+                    XCTAssertEqual(value, nil)
+                } else if count == 1 {
+                    XCTAssertEqual(value, 5)
+                } else if count == 2 {
+                    XCTAssertEqual(value, 17)
+                    return
+                }
+                count += 1
+            }
+        }.store(in: asyncTasks)
+
+        Task {
+            var count = 0
+            for try await value in await property.stream {
+                if count == 0 {
+                    XCTAssertEqual(value, nil)
+                } else if count == 1 {
+                    XCTAssertEqual(value, 5)
+                } else if count == 2 {
+                    XCTAssertEqual(value, 17)
+                    return
+                }
+                count += 1
+            }
+        }.store(in: asyncTasks)
+
+        Task {
+            try? await Task.sleep(nanoseconds: 1000)
+            await property.update(with: 5)
+            try? await Task.sleep(nanoseconds: 1000)
+            await property.update(with: 17)
+            try? await Task.sleep(nanoseconds: 1000)
+            await property.update(with: 20)
+        }
+
+        wait(for: [delegateExpectation], timeout: 1)
+    }
+}

--- a/LucidTests/Utils/CoreManagerPropertyTests.swift
+++ b/LucidTests/Utils/CoreManagerPropertyTests.swift
@@ -1,0 +1,9 @@
+//
+//  CoreManagerPropertyTests.swift
+//  LucidTests
+//
+//  Created by Stephane Magne on 2023-05-16.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
This PR makes a few significant changes in an attempt to move towards full Swift Concurrency and remove `DispatchQueue` objects:

1. Add a new class `AsyncCurrentValue` to mimic `Combine.CurrentValue`.
2. Rewrite `CoreManagerProperty` using the new `AsyncCurrentValue` class.
3. I also add a `CoreManagerAsyncToCombineProperty` to allow the Combine class to fully wrap the results it gets back from the async functions rather to create a new continuous stream.
4. Update `CoreManager` to use these new classes and to return `once` signals as a result instead of a block.
