### PR TITLE
[IPT-8091] Fix possible data races on APIClient calls

### DIFF
--- a/Lucid/Core/APIClient.swift
+++ b/Lucid/Core/APIClient.swift
@@ -642,7 +642,7 @@ extension APIClient {
         }
 
         let completion: (Result<APIClientResponse<Data>, APIError>) async -> Result<APIClientResponse<Data>, APIError> = { result in
-            await self.deduplicator.applyResultToDuplicates(request: requestConfig, result: result)
+            self.deduplicator.applyResultToDuplicates(request: requestConfig, result: result)
             self.didReceive(result: result)
             return result
         }

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -2502,7 +2502,7 @@ final class CoreManagerTests: XCTestCase {
                     XCTAssertEqual(result.first?.title, "fake_title")
                     XCTAssertEqual(result.count, 1)
 
-                    try await Task.sleep(nanoseconds: 500000)
+                    try await Task.sleep(nanoseconds: 1000000)
 
                     XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
                     XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)

--- a/LucidTests/Stores/BaseStoreTests.swift
+++ b/LucidTests/Stores/BaseStoreTests.swift
@@ -323,7 +323,7 @@ class StoreTests: XCTestCase {
         let entities = (1...1000).map { EntitySpy(idValue: .remote($0, nil)) }
 
         let expectation = self.expectation(description: "entity")
-        Task {
+        Task(priority: .high) {
             let result = await entityStore.set(entities, in: WriteContext(dataTarget: .local))
 
             guard let result = result else {


### PR DESCRIPTION
When testing this code on the Scribd app, I noticed there are Data Races due to the fact that the `RemoteStore` is still using the "closure style" code. This was conflicting with the access to the Deduplicator properties since both systems now use different queues. 

This PR unifies the queuing to only use the "async style"

Later on when we add support to the `RemoteStore` and the relevant classes, this will be already solved