### PR TITLE
Update code gen to properly support arrays of Subtypes

### DIFF
--- a/CodeGen/Sources/LucidCodeGen/Generators/CoreDataXCDataModelGenerator.swift
+++ b/CodeGen/Sources/LucidCodeGen/Generators/CoreDataXCDataModelGenerator.swift
@@ -121,7 +121,7 @@ public final class CoreDataXCDataModelGenerator: Generator {
                         <attribute name="__\(propertyCoreDataName)\(parameters.useCoreDataLegacyNaming ? "TypeUID" : "_type_uid")" optional="YES" attributeType="String" syncable="YES"\(_typeUIDElementIDText)/>
                 """
             } else {
-                let optional = property.nullable || property.lazy
+                let optional = property.nullable || property.lazy || property.isArrayOfSubtype
                 let optionalText = optional ? " optional=\"YES\"" : ""
                 let defaultValueText = property.defaultValue.flatMap { " \($0.coreDataAttributeName)=\"\($0.coreDataValue)\"" } ?? ""
 

--- a/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
@@ -430,6 +430,10 @@ public extension EntityProperty {
             return persistedName ?? name
         }
     }
+
+    var isArrayOfSubtype: Bool {
+        return propertyType.isArrayOfSubtype
+    }
 }
 
 public extension EntityProperty.PropertyType {
@@ -499,6 +503,17 @@ public extension EntityProperty.PropertyType {
             return true
         case .relationship(let relationship) where relationship.association == .toMany:
             return true
+        case .relationship,
+             .scalar,
+             .subtype:
+            return false
+        }
+    }
+
+    var isArrayOfSubtype: Bool {
+        switch self {
+        case .array(let subtype):
+            return subtype.isSubtype
         case .relationship,
              .scalar,
              .subtype:

--- a/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
+++ b/CodeGen/Sources/LucidCodeGenCore/Accessors.swift
@@ -474,7 +474,16 @@ public extension EntityProperty.PropertyType {
             return nil
         }
     }
-    
+
+    func subtypeInArray(_ descriptions: Descriptions) throws -> Subtype? {
+        switch self {
+        case .array(let arraySubtype):
+            return try arraySubtype.subtype(descriptions)
+        default:
+            return nil
+        }
+    }
+
     var scalarType: PropertyScalarType? {
         switch self {
         case .scalar(let scalarType):


### PR DESCRIPTION
We weren't handling the CoreData logic properly if there was a default value for a newly added array of Subtypes.

The two key changes are:

1. Add a new decoding function for arrays of subtypes so that it doesn't possibly return a nil value.
2. Make the CoreData property optional.