### PR TITLE
[IPT-8262] Convert RemoteStore to async/await logic

### DIFF
--- a/Lucid/Core/APIClientQueueScheduling.swift
+++ b/Lucid/Core/APIClientQueueScheduling.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public protocol APIClientQueueScheduling: AnyObject {
 
-    func didEnqueueNewRequest()
+    func didEnqueueNewRequest() async
 
-    func flush()
+    func flush() async
 
-    func requestDidSucceed()
+    func requestDidSucceed() async
 
-    func requestDidFail()
+    func requestDidFail() async
 
     var delegate: APIClientQueueSchedulerDelegate? { get set }
 }
@@ -24,7 +24,7 @@ public protocol APIClientQueueScheduling: AnyObject {
 public protocol APIClientQueueSchedulerDelegate: AnyObject {
 
     @discardableResult
-    func processNext() -> APIClientQueueSchedulerProcessNextResult
+    func processNext() async -> APIClientQueueSchedulerProcessNextResult
 }
 
 public enum APIClientQueueSchedulerProcessNextResult {

--- a/Lucid/Stores/RemoteStore.swift
+++ b/Lucid/Stores/RemoteStore.swift
@@ -109,33 +109,29 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
                     Task {
                         do {
                             try await self.decodingAsyncQueue.enqueue {
-                                do {
-                                    switch context.dataSource {
-                                    case ._remote(.request(_, let endpoint), _, _, _):
-                                        let payload = try E.ResultPayload(from: response.data,
-                                                                          endpoint: endpoint,
-                                                                          decoder: response.jsonCoderConfig.decoder)
-                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+                                switch context.dataSource {
+                                case ._remote(.request(_, let endpoint), _, _, _):
+                                    let payload = try E.ResultPayload(from: response.data,
+                                                                      endpoint: endpoint,
+                                                                      decoder: response.jsonCoderConfig.decoder)
+                                    context.set(payloadResult: .success(payload), source: source, for: request.config)
 
-                                    case ._remote(.derivedFromEntityType, _, _, _):
-                                        let payload = try E.ResultPayload(from: response.data,
-                                                                          endpoint: try E.unwrappedEndpoint(for: path),
-                                                                          decoder: response.jsonCoderConfig.decoder)
-                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+                                case ._remote(.derivedFromEntityType, _, _, _):
+                                    let payload = try E.ResultPayload(from: response.data,
+                                                                      endpoint: try E.unwrappedEndpoint(for: path),
+                                                                      decoder: response.jsonCoderConfig.decoder)
+                                    context.set(payloadResult: .success(payload), source: source, for: request.config)
 
-                                    case .local,
-                                            .localOr,
-                                            .localThen:
-                                        Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-                                        return
-                                    }
-
-                                } catch {
-                                    context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                                case .local,
+                                        .localOr,
+                                        .localThen:
+                                    Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
+                                    return
                                 }
                             }
                         } catch {
-                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task")
+                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task: \(error)")
+                            context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
                         }
                     }
 
@@ -235,34 +231,31 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
                     Task {
                         do {
                             try await self.decodingAsyncQueue.enqueue {
-                                do {
-                                    switch context.dataSource {
-                                    case ._remote(.request(_, let endpoint), _, _, _):
+                                switch context.dataSource {
+                                case ._remote(.request(_, let endpoint), _, _, _):
 
-                                        let payload = try E.ResultPayload(from: response.data,
-                                                                          endpoint: endpoint,
-                                                                          decoder: response.jsonCoderConfig.decoder)
-                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+                                    let payload = try E.ResultPayload(from: response.data,
+                                                                      endpoint: endpoint,
+                                                                      decoder: response.jsonCoderConfig.decoder)
+                                    context.set(payloadResult: .success(payload), source: source, for: request.config)
 
-                                    case ._remote(.derivedFromEntityType, _, _, _):
-                                        let path = RemotePath<E>.search(query)
-                                        let payload = try E.ResultPayload(from: response.data,
-                                                                          endpoint: try E.unwrappedEndpoint(for: path),
-                                                                          decoder: response.jsonCoderConfig.decoder)
-                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+                                case ._remote(.derivedFromEntityType, _, _, _):
+                                    let path = RemotePath<E>.search(query)
+                                    let payload = try E.ResultPayload(from: response.data,
+                                                                      endpoint: try E.unwrappedEndpoint(for: path),
+                                                                      decoder: response.jsonCoderConfig.decoder)
+                                    context.set(payloadResult: .success(payload), source: source, for: request.config)
 
-                                    case .local,
-                                            .localOr,
-                                            .localThen:
-                                        Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-                                        return
-                                    }
-                                } catch {
-                                    context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                                case .local,
+                                        .localOr,
+                                        .localThen:
+                                    Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
+                                    return
                                 }
                             }
                         } catch {
-                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task")
+                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task: \(error)")
+                            context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
                         }
                     }
 

--- a/Lucid/Stores/RemoteStore.swift
+++ b/Lucid/Stores/RemoteStore.swift
@@ -40,7 +40,7 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
     /// - Warning: This queue shall only be used for decoding computation.
     ///            It shall never be used for work deferring to other queues synchronously or it would
     ///            introduce a risk of thread pool starvation (no more threads available), leading to a crash.
-    private let decodingQueue = DispatchQueue(label: "\(RemoteStore.self):decoding", attributes: .concurrent)
+    private let decodingAsyncQueue = AsyncTaskQueue()
 
     // MARK: - Inits
 
@@ -52,9 +52,15 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
 
     public func get(withQuery query: Query<E>, in context: ReadContext<E>, completion: @escaping (Result<QueryResult<E>, StoreError>) -> Void) {
 
+        Task {
+            let result = await self.get(withQuery: query, in: context)
+            completion(result)
+        }
+    }
+
+    public func get(withQuery query: Query<E>, in context: ReadContext<E>) async -> Result<QueryResult<E>, StoreError> {
         guard let identifier = query.identifier else {
-            completion(.failure(.identifierNotFound))
-            return
+            return .failure(.identifierNotFound)
         }
 
         let request: APIRequest<Data>
@@ -66,8 +72,7 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
         case ._remote(.derivedFromEntityType, _, _, _):
             guard let newRequest = E.request(for: path, or: context.remoteStoreCache.payloadRequest) else {
                 Logger.log(.error, "\(Self.self): Remote store could not build valid API request from context \(context)", assert: true)
-                completion(.failure(.invalidContext))
-                return
+                return .failure(.invalidContext)
             }
 
             request = newRequest
@@ -81,109 +86,109 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
              .localOr,
              .localThen:
             Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-            completion(.failure(.invalidContext))
-            return
+            return .failure(.invalidContext)
         }
 
         guard request.config.query.hasUnsyncedIdentifiers == false else {
-            completion(.failure(.identifierNotSynced))
-            return
+            return .failure(.identifierNotSynced)
         }
 
-        context.addListener(for: request.config) { result in
-            switch result {
-            case .success(.some(let payload as E.ResultPayload)):
-                if let entity: E = payload.getEntity(for: identifier) {
-                    let metadata = Metadata<E>(payload.metadata)
-                    completion(.success(QueryResult(from: entity, metadata: metadata)))
-                } else {
-                    completion(.failure(.notFoundInPayload))
-                }
+        if hasCachedResponse == false {
 
-            case .success(.some(let payload)):
-                Logger.log(.error, "\(RemoteStore.self): Could not convert \(type(of: payload)) to \(E.ResultPayload.self).", assert: true)
-                completion(.failure(.invalidContext))
+            let requestCompletion: (APIClientQueueResult<Data, APIError>) -> Void = { result in
+                switch result {
+                case .success(let response):
 
-            case .success(.none):
-                completion(.failure(.emptyResponse))
+                    let source: RemoteResponseSource = response.cachedResponse ? .urlCache(.empty) : .server(.empty)
 
-            case .failure(.api(httpStatusCode: 404, _, _)):
-                completion(.success(.empty()))
-
-            case .failure(let error):
-                let error = StoreError.api(error)
-                Logger.log(.error, "\(RemoteStore.self): Error occurred for request path: \(request.config.path): \(error)")
-                completion(.failure(error))
-            }
-        }
-
-        guard hasCachedResponse == false else { return }
-
-        let requestCompletion: (APIClientQueueResult<Data, APIError>) -> Void = { result in
-            switch result {
-            case .success(let response):
-
-                let source: RemoteResponseSource = response.cachedResponse ? .urlCache(.empty) : .server(.empty)
-
-                if response.isNotModified {
-                    context.set(payloadResult: .success(nil), source: source, for: request.config)
-                    return
-                }
-
-                self.decodingQueue.async {
-                    do {
-                        switch context.dataSource {
-                        case ._remote(.request(_, let endpoint), _, _, _):
-                            let payload = try E.ResultPayload(from: response.data,
-                                                              endpoint: endpoint,
-                                                              decoder: response.jsonCoderConfig.decoder)
-                            context.set(payloadResult: .success(payload), source: source, for: request.config)
-
-                        case ._remote(.derivedFromEntityType, _, _, _):
-                            let payload = try E.ResultPayload(from: response.data,
-                                                              endpoint: try E.unwrappedEndpoint(for: path),
-                                                              decoder: response.jsonCoderConfig.decoder)
-                            context.set(payloadResult: .success(payload), source: source, for: request.config)
-
-                        case .local,
-                             .localOr,
-                             .localThen:
-                            Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-                            return
-                        }
-
-                    } catch {
-                        context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                    if response.isNotModified {
+                        context.set(payloadResult: .success(nil), source: source, for: request.config)
+                        return
                     }
+
+                    Task {
+                        do {
+                            try await self.decodingAsyncQueue.enqueue {
+                                do {
+                                    switch context.dataSource {
+                                    case ._remote(.request(_, let endpoint), _, _, _):
+                                        let payload = try E.ResultPayload(from: response.data,
+                                                                          endpoint: endpoint,
+                                                                          decoder: response.jsonCoderConfig.decoder)
+                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+
+                                    case ._remote(.derivedFromEntityType, _, _, _):
+                                        let payload = try E.ResultPayload(from: response.data,
+                                                                          endpoint: try E.unwrappedEndpoint(for: path),
+                                                                          decoder: response.jsonCoderConfig.decoder)
+                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+
+                                    case .local,
+                                            .localOr,
+                                            .localThen:
+                                        Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
+                                        return
+                                    }
+
+                                } catch {
+                                    context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                                }
+                            }
+                        } catch {
+                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task")
+                        }
+                    }
+
+                case .aborted:
+                    context.set(payloadResult: .failure(.network(.cancelled)), source: nil, for: request.config)
+
+                case .failure(let error):
+                    context.set(payloadResult: .failure(error), source: nil, for: request.config)
                 }
+            }
 
-            case .aborted:
-                context.set(payloadResult: .failure(.network(.cancelled)), source: nil, for: request.config)
-
-            case .failure(let error):
-                context.set(payloadResult: .failure(error), source: nil, for: request.config)
+            Task {
+                let identifiers = query.identifiers?.array ?? []
+                let clientQueueRequest = APIClientQueueRequest(wrapping: request, identifiers: identifiers)
+                await completeOnClientQueueResponse(for: [clientQueueRequest]) { result in
+                    requestCompletion(result)
+                }
+                await clientQueue.append(clientQueueRequest)
             }
         }
 
-        let identifiers = query.identifiers?.array ?? []
-        let clientQueueRequest = APIClientQueueRequest(wrapping: request, identifiers: identifiers)
-        completeOnClientQueueResponse(for: [clientQueueRequest]) { result in
-            requestCompletion(result)
-        }
-        clientQueue.append(clientQueueRequest)
-    }
-
-    public func get(withQuery query: Query<E>, in context: ReadContext<E>) async -> Result<QueryResult<E>, StoreError> {
         return await withCheckedContinuation { continuation in
-            self.get(withQuery: query, in: context, completion: { result in
-                continuation.resume(returning: result)
-            })
+            context.addListener(for: request.config) { result in
+                switch result {
+                case .success(.some(let payload as E.ResultPayload)):
+                    if let entity: E = payload.getEntity(for: identifier) {
+                        let metadata = Metadata<E>(payload.metadata)
+                        continuation.resume(returning: .success(QueryResult(from: entity, metadata: metadata)))
+                    } else {
+                        continuation.resume(returning: .failure(.notFoundInPayload))
+                    }
+
+                case .success(.some(let payload)):
+                    Logger.log(.error, "\(RemoteStore.self): Could not convert \(type(of: payload)) to \(E.ResultPayload.self).", assert: true)
+                    continuation.resume(returning: .failure(.invalidContext))
+
+                case .success(.none):
+                    continuation.resume(returning: .failure(.emptyResponse))
+
+                case .failure(.api(httpStatusCode: 404, _, _)):
+                    continuation.resume(returning: .success(.empty()))
+
+                case .failure(let error):
+                    let error = StoreError.api(error)
+                    Logger.log(.error, "\(RemoteStore.self): Error occurred for request path: \(request.config.path): \(error)")
+                    continuation.resume(returning: .failure(error))
+                }
+            }
         }
     }
 
     private func coreSearch(withQuery query: Query<E>,
-                            in context: ReadContext<E>,
-                            completion: @escaping (Result<(result: QueryResult<E>, isFromCache: Bool), StoreError>) -> Void) {
+                            in context: ReadContext<E>) async -> Result<(result: QueryResult<E>, isFromCache: Bool), StoreError> {
 
         let request: APIRequest<Data>
         let hasCachedResponse: Bool
@@ -193,8 +198,7 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
             let path = RemotePath<E>.search(query)
             guard let newRequest = E.request(for: path, or: context.remoteStoreCache.payloadRequest) else {
                 Logger.log(.error, "\(Self.self): could not build valid request.", assert: true)
-                completion(.failure(.invalidContext))
-                return
+                return .failure(.invalidContext)
             }
 
             request = newRequest
@@ -208,152 +212,162 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
              .localOr,
              .localThen:
             Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-            completion(.failure(.invalidContext))
-            return
+            return .failure(.invalidContext)
         }
 
-        context.addListener(for: request.config) { result in
-            switch result {
-            case .success(.some(let payload as E.ResultPayload)):
-                let entities: AnySequence<E>
-                let alreadyFiltered: Bool = context.trustRemoteFiltering && hasCachedResponse == false
-                if alreadyFiltered {
-                    entities = payload.allEntities()
-                } else {
-                    entities = payload.allEntities().filter(with: query.filter)
-                }
-                let searchResult = QueryResult(
-                    from: entities,
-                    for: query,
-                    alreadyPaginated: alreadyFiltered,
-                    metadata: Metadata<E>(payload.metadata)
-                )
-                completion(.success((searchResult, hasCachedResponse)))
+        if hasCachedResponse == false {
 
-            case .success(.some(let payload)):
-                Logger.log(.error, "\(RemoteStore.self): Could not convert \(type(of: payload)) to \(E.ResultPayload.self)", assert: true)
-                completion(.failure(.invalidContext))
-
-            case .success(.none):
-                completion(.failure(.emptyResponse))
-
-            case .failure(let error):
-                let error = StoreError.api(error)
-                Logger.log(.error, "\(RemoteStore.self): Error occurred for request path: \(request.config.path): \(error)")
-                completion(.failure(error))
+            guard request.config.query.hasUnsyncedIdentifiers == false else {
+                return .failure(.identifierNotSynced)
             }
-        }
 
-        guard hasCachedResponse == false else { return }
+            let requestCompletion: (APIClientQueueResult<Data, APIError>) -> Void = { result in
+                switch result {
+                case .success(let response):
 
-        guard request.config.query.hasUnsyncedIdentifiers == false else {
-            completion(.failure(.identifierNotSynced))
-            return
-        }
+                    let source: RemoteResponseSource = response.cachedResponse ? .urlCache(response.header) : .server(response.header)
 
-        let requestCompletion: (APIClientQueueResult<Data, APIError>) -> Void = { result in
-            switch result {
-            case .success(let response):
-
-                let source: RemoteResponseSource = response.cachedResponse ? .urlCache(response.header) : .server(response.header)
-
-                if response.isNotModified {
-                    context.set(payloadResult: .success(nil), source: source, for: request.config)
-                    return
-                }
-
-                self.decodingQueue.async {
-                    do {
-                        switch context.dataSource {
-                        case ._remote(.request(_, let endpoint), _, _, _):
-
-                            let payload = try E.ResultPayload(from: response.data,
-                                                              endpoint: endpoint,
-                                                              decoder: response.jsonCoderConfig.decoder)
-                            context.set(payloadResult: .success(payload), source: source, for: request.config)
-
-                        case ._remote(.derivedFromEntityType, _, _, _):
-                            let path = RemotePath<E>.search(query)
-                            let payload = try E.ResultPayload(from: response.data,
-                                                              endpoint: try E.unwrappedEndpoint(for: path),
-                                                              decoder: response.jsonCoderConfig.decoder)
-                            context.set(payloadResult: .success(payload), source: source, for: request.config)
-
-                        case .local,
-                             .localOr,
-                             .localThen:
-                            Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
-                            return
-                        }
-                    } catch {
-                        context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                    if response.isNotModified {
+                        context.set(payloadResult: .success(nil), source: source, for: request.config)
+                        return
                     }
+
+                    Task {
+                        do {
+                            try await self.decodingAsyncQueue.enqueue {
+                                do {
+                                    switch context.dataSource {
+                                    case ._remote(.request(_, let endpoint), _, _, _):
+
+                                        let payload = try E.ResultPayload(from: response.data,
+                                                                          endpoint: endpoint,
+                                                                          decoder: response.jsonCoderConfig.decoder)
+                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+
+                                    case ._remote(.derivedFromEntityType, _, _, _):
+                                        let path = RemotePath<E>.search(query)
+                                        let payload = try E.ResultPayload(from: response.data,
+                                                                          endpoint: try E.unwrappedEndpoint(for: path),
+                                                                          decoder: response.jsonCoderConfig.decoder)
+                                        context.set(payloadResult: .success(payload), source: source, for: request.config)
+
+                                    case .local,
+                                            .localOr,
+                                            .localThen:
+                                        Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data source \(context.dataSource).", assert: true)
+                                        return
+                                    }
+                                } catch {
+                                    context.set(payloadResult: .failure(.deserialization(error)), source: source, for: request.config)
+                                }
+                            }
+                        } catch {
+                            Logger.log(.error, "\(RemoteStore.self) found error while enqueuing async task")
+                        }
+                    }
+
+                case .aborted:
+                    context.set(payloadResult: .failure(.network(.cancelled)), source: nil, for: request.config)
+
+                case .failure(let error):
+                    context.set(payloadResult: .failure(error), source: nil, for: request.config)
                 }
+            }
 
-            case .aborted:
-                context.set(payloadResult: .failure(.network(.cancelled)), source: nil, for: request.config)
-
-            case .failure(let error):
-                context.set(payloadResult: .failure(error), source: nil, for: request.config)
+            Task {
+                let identifiers = query.identifiers?.array ?? []
+                let clientQueueRequest = APIClientQueueRequest(wrapping: request, identifiers: identifiers)
+                await completeOnClientQueueResponse(for: [clientQueueRequest]) { result in
+                    requestCompletion(result)
+                }
+                await clientQueue.append(clientQueueRequest)
             }
         }
 
-        let identifiers = query.identifiers?.array ?? []
-        let clientQueueRequest = APIClientQueueRequest(wrapping: request, identifiers: identifiers)
-        completeOnClientQueueResponse(for: [clientQueueRequest]) { result in
-            requestCompletion(result)
+        return await withCheckedContinuation { continuation in
+            context.addListener(for: request.config) { result in
+                switch result {
+                case .success(.some(let payload as E.ResultPayload)):
+                    let entities: AnySequence<E>
+                    let alreadyFiltered: Bool = context.trustRemoteFiltering && hasCachedResponse == false
+                    if alreadyFiltered {
+                        entities = payload.allEntities()
+                    } else {
+                        entities = payload.allEntities().filter(with: query.filter)
+                    }
+                    let searchResult = QueryResult(
+                        from: entities,
+                        for: query,
+                        alreadyPaginated: alreadyFiltered,
+                        metadata: Metadata<E>(payload.metadata)
+                    )
+                    continuation.resume(returning: .success((searchResult, hasCachedResponse)))
+
+                case .success(.some(let payload)):
+                    Logger.log(.error, "\(RemoteStore.self): Could not convert \(type(of: payload)) to \(E.ResultPayload.self)", assert: true)
+                    continuation.resume(returning: .failure(.invalidContext))
+
+                case .success(.none):
+                    continuation.resume(returning: .failure(.emptyResponse))
+
+                case .failure(let error):
+                    let error = StoreError.api(error)
+                    Logger.log(.error, "\(RemoteStore.self): Error occurred for request path: \(request.config.path): \(error)")
+                    continuation.resume(returning: .failure(error))
+                }
+            }
         }
-        clientQueue.append(clientQueueRequest)
     }
 
     public func search(withQuery query: Query<E>,
                        in context: ReadContext<E>,
                        completion: @escaping (Result<QueryResult<E>, StoreError>) -> Void) {
 
-        // Some payloads need to filter out entities which aren't meant to be at their root level.
-        // This is due to the fact that payloads made of a tree structure get their data automatically flattened.
-        coreSearch(withQuery: query, in: context) { result in
-            switch result {
-            case .success(let response):
-
-                guard let allItems = response.result.metadata?.allItems else {
-                    completion(.success(response.result))
-                    return
-                }
-
-                let rootIdentifiers = DualHashSet<E.Identifier>(allItems.lazy.compactMap { $0.entityIdentifier() })
-                guard rootIdentifiers.isEmpty == false else {
-                    completion(.success(response.result))
-                    return
-                }
-
-                guard response.isFromCache == false else {
-                    completion(.success(response.result))
-                    return
-                }
-
-                let filteredEntities = response.result.filter { rootIdentifiers.contains($0.identifier) }
-
-                completion(.success(QueryResult<E>(fromProcessedEntities: filteredEntities,
-                                                   for: query,
-                                                   metadata: response.result.metadata)))
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        Task {
+            let result = await self.search(withQuery: query, in: context)
+            completion(result)
         }
     }
 
     public func search(withQuery query: Query<E>, in context: ReadContext<E>) async -> Result<QueryResult<E>, StoreError> {
-        return await withCheckedContinuation { continuation in
-            self.search(withQuery: query, in: context, completion: { result in
-                continuation.resume(returning: result)
-            })
+        // Some payloads need to filter out entities which aren't meant to be at their root level.
+        // This is due to the fact that payloads made of a tree structure get their data automatically flattened.
+        let result = await coreSearch(withQuery: query, in: context)
+        switch result {
+        case .success(let response):
+
+            guard let allItems = response.result.metadata?.allItems else {
+                return .success(response.result)
+            }
+
+            let rootIdentifiers = DualHashSet<E.Identifier>(allItems.lazy.compactMap { $0.entityIdentifier() })
+            guard rootIdentifiers.isEmpty == false else {
+                return .success(response.result)
+            }
+
+            guard response.isFromCache == false else {
+                return .success(response.result)
+            }
+
+            let filteredEntities = response.result.filter { rootIdentifiers.contains($0.identifier) }
+
+            return .success(QueryResult<E>(fromProcessedEntities: filteredEntities,
+                                           for: query,
+                                           metadata: response.result.metadata))
+
+        case .failure(let error):
+            return .failure(error)
         }
     }
 
     public func set<S>(_ entities: S, in context: WriteContext<E>, completion: @escaping (Result<AnySequence<E>, StoreError>?) -> Void) where S: Sequence, S.Element == E {
+        Task {
+            let result = await set(entities, in: context)
+            completion(result)
+        }
+    }
 
+    public func set<S>(_ entities: S, in context: WriteContext<E>) async -> Result<AnySequence<E>, StoreError>? where S : Sequence, E == S.Element {
         var countMismatch = false
 
         let requests: [APIClientQueueRequest]
@@ -390,38 +404,40 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
 
         case .local:
             Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data target \(context.dataTarget).", assert: true)
-            completion(.failure(.invalidContext))
-            return
+            return .failure(.invalidContext)
         }
 
         guard countMismatch == false else {
-            completion(.failure(.notSupported))
-            return
+            return .failure(.notSupported)
         }
 
         for entity in entities {
             entity.identifier.willBePushedToClientQueue()
         }
 
-        completeOnClientQueueResponse(for: requests) { _ in
-            completion(nil)
+        Task {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        await self.clientQueue.append(request)
+                    }
+                }
+            }
         }
 
-        for request in requests {
-            clientQueue.append(request)
-        }
-    }
-
-    public func set<S>(_ entities: S, in context: WriteContext<E>) async -> Result<AnySequence<E>, StoreError>? where S : Sequence, E == S.Element {
         return await withCheckedContinuation { continuation in
-            self.set(entities, in: context, completion: { result in
-                continuation.resume(returning: result)
-            })
+            continuation.resume(returning: nil)
         }
     }
 
     public func removeAll(withQuery query: Query<E>, in context: WriteContext<E>, completion: @escaping (Result<AnySequence<E.Identifier>, StoreError>?) -> Void) {
+        Task {
+            let result = await removeAll(withQuery: query, in: context)
+            completion(result)
+        }
+    }
 
+    public func removeAll(withQuery query: Query<E>, in context: WriteContext<E>) async -> Result<AnySequence<E.Identifier>, StoreError>? {
         let path = RemotePath<E>.removeAll(query)
         let identifiers = query.identifiers?.array ?? []
         let clientQueueRequest: APIClientQueueRequest
@@ -430,8 +446,7 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
         case .localAndRemote(.derivedFromEntityType),
              .remote(.derivedFromEntityType):
             guard let request = E.request(for: path, or: nil) else {
-                completion(.failure(.notSupported))
-                return
+                return .failure(.notSupported)
             }
 
             let identifiers = query.identifiers?.array ?? []
@@ -440,7 +455,7 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
         case .localAndRemote(.derivedFromPath),
              .remote(.derivedFromPath):
             Logger.log(.error, "\(Self.self): For .removeAll, use endpoint .request instead.", assert: true)
-            return
+            return .failure(.notSupported)
 
         case .localAndRemote(.request(let config)),
              .remote(.request(let config)):
@@ -449,26 +464,25 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
 
         case .local:
             Logger.log(.error, "\(Self.self): Remote store should not be attempting to handle data target \(context.dataTarget).", assert: true)
-            return
+            return .failure(.notSupported)
         }
 
-        completeOnClientQueueResponse(for: [clientQueueRequest]) { _ in
-            completion(nil)
-        }
+        await completeOnClientQueueResponse(for: [clientQueueRequest]) { _ in }
 
-        clientQueue.append(clientQueueRequest)
-    }
+        await clientQueue.append(clientQueueRequest)
 
-    public func removeAll(withQuery query: Query<E>, in context: WriteContext<E>) async -> Result<AnySequence<E.Identifier>, StoreError>? {
-        return await withCheckedContinuation { continuation in
-            self.removeAll(withQuery: query, in: context, completion: { result in
-                continuation.resume(returning: result)
-            })
-        }
+        return nil
     }
 
     public func remove<S>(_ identifiers: S, in context: WriteContext<E>, completion: @escaping (Result<Void, StoreError>?) -> Void) where S: Sequence, S.Element == E.Identifier {
 
+        Task {
+            let result = await remove(identifiers, in: context)
+            completion(result)
+        }
+    }
+
+    public func remove<S>(_ identifiers: S, in context: WriteContext<E>) async -> Result<Void, StoreError>? where S : Sequence, S.Element == E.Identifier {
         var countMismatch = false
         let requests = identifiers.compactMap { (identifier: E.Identifier) -> APIClientQueueRequest? in
 
@@ -503,24 +517,23 @@ public final class RemoteStore<E>: StoringConvertible where E: RemoteEntity {
         }
 
         guard countMismatch == false else {
-            completion(.failure(.notSupported))
-            return
+            return .failure(.notSupported)
         }
 
-        completeOnClientQueueResponse(for: requests) { _ in
-            completion(nil)
+        Task {
+            await withTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        await self.clientQueue.append(request)
+                    }
+                }
+            }
         }
 
-        for request in requests {
-            clientQueue.append(request)
-        }
-    }
-
-    public func remove<S>(_ identifiers: S, in context: WriteContext<E>) async -> Result<Void, StoreError>? where S : Sequence, S.Element == E.Identifier {
         return await withCheckedContinuation { continuation in
-            self.remove(identifiers, in: context, completion: { result in
-                continuation.resume(returning: result)
-            })
+            await self.completeOnClientQueueResponse(for: requests) { _ in
+                continuation.resume(returning: nil)
+            }
         }
     }
 }
@@ -583,12 +596,14 @@ private extension RemoteStore {
         }
     }
 
-    func completeOnClientQueueResponse<S>(for requests: S, completion: @escaping (APIClientQueueResult<Data, APIError>) -> Void) where S: Sequence, S.Element == APIClientQueueRequest {
+    func completeOnClientQueueResponse<S>(for requests: S, completion: @escaping (APIClientQueueResult<Data, APIError>) -> Void) async where S: Sequence, S.Element == APIClientQueueRequest {
         var responseHandlerToken: APIClientQueueResponseHandlerToken?
-        responseHandlerToken = clientQueue.register(
+        responseHandlerToken = await clientQueue.register(
             ClientQueueResponseHandler(requests) { result in
                 if let token = responseHandlerToken {
-                    self.clientQueue.unregister(token)
+                    Task {
+                        await self.clientQueue.unregister(token)
+                    }
                 }
                 completion(result)
             }

--- a/LucidTestKit/Doubles/APIClientQueueSpy.swift
+++ b/LucidTestKit/Doubles/APIClientQueueSpy.swift
@@ -35,7 +35,7 @@ public final class APIClientQueueSpy: APIClientQueuing, APIClientQueueFlushing {
         // no-op
     }
 
-    public func append(_ request: APIClientQueueRequest) {
+    public func append(_ request: APIClientQueueRequest) async {
         appendInvocations.append(request)
         registerInvocations.forEach {
             guard let response = responseStubs[request.wrapped.config] else { return }
@@ -43,16 +43,16 @@ public final class APIClientQueueSpy: APIClientQueuing, APIClientQueueFlushing {
         }
     }
 
-    public func flush() {
+    public func flush() async {
         flushInvocations += 1
     }
 
-    public func register(_ handler: APIClientQueueResponseHandler) -> APIClientQueueProcessorResponseHandlerToken {
+    public func register(_ handler: APIClientQueueResponseHandler) async -> APIClientQueueProcessorResponseHandlerToken {
         registerInvocations.append(handler)
         return tokenStub
     }
 
-    public func unregister(_ token: APIClientQueueResponseHandlerToken) {
+    public func unregister(_ token: APIClientQueueResponseHandlerToken) async {
         unregisterInvocations.append(token)
     }
 

--- a/LucidTests/Core/APIClientQueueTests.swift
+++ b/LucidTests/Core/APIClientQueueTests.swift
@@ -22,7 +22,7 @@ final class APIClientQueueTests: XCTestCase {
 
     // MARK: - Doubles
 
-    private var uniquingCacheDataQueue: DispatchQueue!
+    private var uniquingCacheDataQueue: AsyncTaskQueue!
     private var uniquingFunction: ((APIClientQueueRequest) -> String)!
 
     // MARK: - Subject
@@ -39,7 +39,7 @@ final class APIClientQueueTests: XCTestCase {
         uniquingQueueOrderingCache = DiskCacheSpy()
         uniquingQueueValueCache = DiskCacheSpy()
         queueProcessor = APIClientQueueProcessorSpy()
-        uniquingCacheDataQueue = DispatchQueue(label: "\(APIClientQueueTests.self)_uniquing_cache_data_queue")
+        uniquingCacheDataQueue = AsyncTaskQueue()
 
         defaultQueue = APIClientQueue(cache: .default(DiskQueue(diskCache: defaultQueueCache.caching)),
                                       processor: queueProcessor)
@@ -99,61 +99,61 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_append_should_add_an_element_to_the_default_queue_when_it_is_empty() {
+    func test_append_should_add_an_element_to_the_default_queue_when_it_is_empty() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
-        defaultQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await defaultQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 1)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request)
     }
 
-    func test_append_should_add_an_element_to_the_default_queue_when_it_has_other_elements() {
+    func test_append_should_add_an_element_to_the_default_queue_when_it_has_other_elements() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 2)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request0)
         XCTAssertEqual(defaultQueueCache.setInvocations[1].1, request1)
     }
 
-    func test_append_to_empty_default_queue_should_trigger_a_call_to_the_processor() {
+    func test_append_to_empty_default_queue_should_trigger_a_call_to_the_processor() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
 
-        defaultQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await defaultQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 1)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
     }
 
-    func test_calling_append_to_default_queue_twice_should_trigger_two_calls_to_the_processor() {
+    func test_calling_append_to_default_queue_twice_should_trigger_two_calls_to_the_processor() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 2)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -164,47 +164,47 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_prepend_should_add_an_element_to_the_default_queue_when_it_is_empty() {
+    func test_prepend_should_add_an_element_to_the_default_queue_when_it_is_empty() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
-        defaultQueue.prepend(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await defaultQueue.prepend(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 1)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request)
     }
 
-    func test_prepend_should_add_an_element_to_the_default_queue_when_it_has_other_elements() {
+    func test_prepend_should_add_an_element_to_the_default_queue_when_it_has_other_elements() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
-        defaultQueue.prepend(request0)
-        defaultQueue.prepend(request1)
+        await defaultQueue.prepend(request0)
+        await defaultQueue.prepend(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 2)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request0)
         XCTAssertEqual(defaultQueueCache.setInvocations[1].1, request1)
     }
 
-    func test_prepend_to_default_queue_should_not_trigger_a_call_to_the_processor() {
+    func test_prepend_to_default_queue_should_not_trigger_a_call_to_the_processor() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        defaultQueue.prepend(request0)
-        defaultQueue.prepend(request1)
+        await defaultQueue.prepend(request0)
+        await defaultQueue.prepend(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -215,16 +215,16 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_append_should_add_an_element_to_the_uniquing_queue_when_it_is_empty() {
+    func test_append_should_add_an_element_to_the_uniquing_queue_when_it_is_empty() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 0)
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations.count, 0)
 
-        uniquingQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-        uniquingCacheDataQueue.sync { }
+        await uniquingQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 1)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -235,20 +235,20 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations[0].1, request)
     }
 
-    func test_append_should_add_an_element_to_the_uniquing_queue_when_it_only_contains_elements_with_different_keys() {
+    func test_append_should_add_an_element_to_the_uniquing_queue_when_it_only_contains_elements_with_different_keys() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 0)
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -263,7 +263,7 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations[1].1, request1)
     }
 
-    func test_append_should_overwrite_elements_with_matching_keys_in_the_uniquing_queue_and_abort_the_existing_request() {
+    func test_append_should_overwrite_elements_with_matching_keys_in_the_uniquing_queue_and_abort_the_existing_request() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host0", path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host0", path: .path("fake_path2")))
@@ -271,15 +271,15 @@ extension APIClientQueueTests {
 
         XCTAssertEqual(uniquingQueueOrderingCache.setInvocations.count, 0)
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
-        uniquingQueue.append(request2)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
+        await uniquingQueue.append(request2)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 3)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -300,34 +300,34 @@ extension APIClientQueueTests {
         XCTAssertEqual(queueProcessor.abortRequestInvocations, [request0])
     }
 
-    func test_append_to_empty_uniquing_queue_should_trigger_a_call_to_the_processor() {
+    func test_append_to_empty_uniquing_queue_should_trigger_a_call_to_the_processor() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
 
-        uniquingQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await uniquingQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 1)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
     }
 
-    func test_calling_append_to_uniquing_queue_twice_should_trigger_two_calls_to_the_processor() {
+    func test_calling_append_to_uniquing_queue_twice_should_trigger_two_calls_to_the_processor() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 2)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -338,17 +338,17 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_prepend_should_add_an_element_to_the_uniquing_queue_when_it_is_empty() {
+    func test_prepend_should_add_an_element_to_the_uniquing_queue_when_it_is_empty() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 0)
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations.count, 0)
 
-        uniquingQueue.prepend(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await uniquingQueue.prepend(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 1)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -359,20 +359,20 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations[0].1, request)
     }
 
-    func test_prepend_should_add_an_element_to_the_uniquing_queue_when_it_only_contains_elements_with_different_keys() {
+    func test_prepend_should_add_an_element_to_the_uniquing_queue_when_it_only_contains_elements_with_different_keys() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 0)
 
-        uniquingQueue.prepend(request0)
-        uniquingQueue.prepend(request1)
+        await uniquingQueue.prepend(request0)
+        await uniquingQueue.prepend(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -387,7 +387,7 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations[1].1, request1)
     }
 
-    func test_prepend_should_not_overwrite_elements_with_matching_keys_in_the_uniquing_queue() {
+    func test_prepend_should_not_overwrite_elements_with_matching_keys_in_the_uniquing_queue() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host0", path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host0", path: .path("fake_path2")))
@@ -395,15 +395,15 @@ extension APIClientQueueTests {
 
         XCTAssertEqual(uniquingQueueOrderingCache.setInvocations.count, 0)
 
-        uniquingQueue.prepend(request0)
-        uniquingQueue.prepend(request1)
-        uniquingQueue.prepend(request2)
+        await uniquingQueue.prepend(request0)
+        await uniquingQueue.prepend(request1)
+        await uniquingQueue.prepend(request2)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -418,18 +418,18 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations[1].1, request1)
     }
 
-    func test_prepend_to_uniquing_queue_should_not_trigger_a_call_to_the_processor() {
+    func test_prepend_to_uniquing_queue_should_not_trigger_a_call_to_the_processor() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        uniquingQueue.prepend(request0)
-        uniquingQueue.prepend(request1)
+        await uniquingQueue.prepend(request0)
+        await uniquingQueue.prepend(request1)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -440,21 +440,21 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_calling_flush_should_only_send_once_regardless_of_size_of_default_queue() {
+    func test_calling_flush_should_only_send_once_regardless_of_size_of_default_queue() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path3")))
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
-        defaultQueue.append(request2)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
+        await defaultQueue.append(request2)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        defaultQueue.flush()
+        await defaultQueue.flush()
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 3)
         XCTAssertEqual(queueProcessor.flushInvocations, 1)
@@ -465,23 +465,23 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_calling_flush_should_only_send_once_regardless_of_size_of_uniquing_queue() {
+    func test_calling_flush_should_only_send_once_regardless_of_size_of_uniquing_queue() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path3")))
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
-        uniquingQueue.append(request2)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
+        await uniquingQueue.append(request2)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
-        uniquingQueue.flush()
+        await uniquingQueue.flush()
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 3)
         XCTAssertEqual(queueProcessor.flushInvocations, 1)
@@ -492,43 +492,43 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_calling_next_request_on_default_queue_returns_request_and_empties_it() {
+    func test_calling_next_request_on_default_queue_returns_request_and_empties_it() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
-        defaultQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await defaultQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
-        let retrievedRequest = defaultQueue.nextRequest()
+        let retrievedRequest = await defaultQueue.nextRequest()
 
         XCTAssertEqual(retrievedRequest, request)
         XCTAssertEqual(defaultQueueCache.values.count, 0)
     }
 
-    func test_calling_next_request_on_default_queue_returns_requests_in_order() {
+    func test_calling_next_request_on_default_queue_returns_requests_in_order() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path3")))
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
-        defaultQueue.append(request2)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
+        await defaultQueue.append(request2)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        let retrievedRequest0 = defaultQueue.nextRequest()
+        let retrievedRequest0 = await defaultQueue.nextRequest()
         XCTAssertEqual(request0, retrievedRequest0)
 
-        let retrievedRequest1 = defaultQueue.nextRequest()
+        let retrievedRequest1 = await defaultQueue.nextRequest()
         XCTAssertEqual(request1, retrievedRequest1)
 
-        let retrievedRequest2 = defaultQueue.nextRequest()
+        let retrievedRequest2 = await defaultQueue.nextRequest()
         XCTAssertEqual(request2, retrievedRequest2)
 
-        let retrievedRequest3 = defaultQueue.nextRequest()
+        let retrievedRequest3 = await defaultQueue.nextRequest()
         XCTAssertNil(retrievedRequest3)
     }
 }
@@ -537,47 +537,47 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_calling_next_request_on_uniquing_queue_returns_request_and_empties_it() {
+    func test_calling_next_request_on_uniquing_queue_returns_request_and_empties_it() async {
 
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
-        uniquingQueue.append(request)
-        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
+        await uniquingQueue.append(request)
+//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
-        let retrievedRequest = uniquingQueue.nextRequest()
+        let retrievedRequest = await uniquingQueue.nextRequest()
 
         XCTAssertEqual(retrievedRequest, request)
         XCTAssertEqual(defaultQueueCache.values.count, 0)
     }
 
-    func test_calling_next_request_on_uniquing_queue_returns_unique_requests_in_order() {
+    func test_calling_next_request_on_uniquing_queue_returns_unique_requests_in_order() async {
 
         let request0 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host0", path: .path("fake_path1")))
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host1", path: .path("fake_path1")))
         let request2 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host2", path: .path("fake_path2")))
         let request3 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, host: "host3", path: .path("fake_path2")))
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
-        uniquingQueue.append(request2)
-        uniquingQueue.append(request3)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
+        await uniquingQueue.append(request2)
+        await uniquingQueue.append(request3)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
 
-        uniquingCacheDataQueue.sync { }
+//        uniquingCacheDataQueue.sync { }
 
-        let retrievedRequest0 = uniquingQueue.nextRequest()
+        let retrievedRequest0 = await uniquingQueue.nextRequest()
         XCTAssertEqual(request1, retrievedRequest0)
 
-        let retrievedRequest1 = uniquingQueue.nextRequest()
+        let retrievedRequest1 = await uniquingQueue.nextRequest()
         XCTAssertEqual(request3, retrievedRequest1)
 
-        let retrievedRequest2 = uniquingQueue.nextRequest()
+        let retrievedRequest2 = await uniquingQueue.nextRequest()
         XCTAssertNil(retrievedRequest2)
     }
 }
@@ -586,7 +586,7 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_merging_an_identifier_should_inject_that_identifier_in_every_matching_request_in_the_queue() {
+    func test_merging_an_identifier_should_inject_that_identifier_in_every_matching_request_in_the_queue() async {
 
         let localIdentifier = EntitySpyIdentifier(value: .local("1"))
         let localIdentifierData = "[{\"local\":\"1\"}]".data(using: .utf8)
@@ -595,21 +595,18 @@ extension APIClientQueueTests {
                                              identifiers: localIdentifierData)
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
-
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
 
         let remoteIdentifier = EntitySpyIdentifier(value: .remote(1, "1"))
-        defaultQueue.merge(with: remoteIdentifier)
+        await defaultQueue.merge(with: remoteIdentifier)
 
         XCTAssertEqual(request0.wrapped.config.path.description, "fake_path1/:identifier_entity_spy:1")
 
-        let retrievedRequest0 = defaultQueue.nextRequest()
+        let retrievedRequest0 = await defaultQueue.nextRequest()
         XCTAssertEqual(retrievedRequest0?.wrapped.config.path.description, "fake_path1/1")
 
-        let retrievedRequest1 = defaultQueue.nextRequest()
+        let retrievedRequest1 = await defaultQueue.nextRequest()
         XCTAssertEqual(retrievedRequest1, request1)
     }
 }
@@ -618,7 +615,7 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_merging_an_identifier_should_inject_that_identifier_in_every_matching_request_in_the_uniquing_queue() {
+    func test_merging_an_identifier_should_inject_that_identifier_in_every_matching_request_in_the_uniquing_queue() async {
 
         let localIdentifier = EntitySpyIdentifier(value: .local("1"))
         let localIdentifierData = "[{\"local\":\"1\"}]".data(using: .utf8)
@@ -627,23 +624,18 @@ extension APIClientQueueTests {
                                              identifiers: localIdentifierData)
         let request1 = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path2")))
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
-
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
-        uniquingCacheDataQueue.sync { }
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
 
         let remoteIdentifier = EntitySpyIdentifier(value: .remote(1, "1"))
-        uniquingQueue.merge(with: remoteIdentifier)
+        await uniquingQueue.merge(with: remoteIdentifier)
 
         XCTAssertEqual(request0.wrapped.config.path.description, "fake_path1/:identifier_entity_spy:1")
 
-        let retrievedRequest0 = uniquingQueue.nextRequest()
+        let retrievedRequest0 = await uniquingQueue.nextRequest()
         XCTAssertEqual(retrievedRequest0?.wrapped.config.path.description, "fake_path1/1")
 
-        let retrievedRequest1 = uniquingQueue.nextRequest()
+        let retrievedRequest1 = await uniquingQueue.nextRequest()
         XCTAssertEqual(retrievedRequest1, request1)
     }
 }
@@ -652,7 +644,7 @@ extension APIClientQueueTests {
 
 extension APIClientQueueTests {
 
-    func test_remove_requests_should_remove_every_request_matching_the_filter_in_the_queue() {
+    func test_remove_requests_should_remove_every_request_matching_the_filter_in_the_queue() async {
 
         let localIdentifierData = "[{\"local\":\"1\"}]".data(using: .utf8)
 
@@ -668,17 +660,17 @@ extension APIClientQueueTests {
         let config3 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request3 = APIClientQueueRequest(wrapping: APIRequest<Data>(config3), identifiers: localIdentifierData)
 
-        defaultQueue.append(request0)
-        defaultQueue.append(request1)
-        defaultQueue.append(request2)
-        defaultQueue.append(request3)
+        await defaultQueue.append(request0)
+        await defaultQueue.append(request1)
+        await defaultQueue.append(request2)
+        await defaultQueue.append(request3)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
+//        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
 
-        let removedRequests = defaultQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
+        let removedRequests = await defaultQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
 
         // test correct requests were removed
         XCTAssertEqual(removedRequests.count, 2)
@@ -686,17 +678,17 @@ extension APIClientQueueTests {
         XCTAssertEqual(removedRequests.last?.wrapped.config, config3)
 
         // test remaining queue is correct
-        let retrievedRequest0 = defaultQueue.nextRequest()
+        let retrievedRequest0 = await defaultQueue.nextRequest()
         XCTAssertEqual(retrievedRequest0?.wrapped.config, config0)
 
-        let retrievedRequest1 = defaultQueue.nextRequest()
+        let retrievedRequest1 = await defaultQueue.nextRequest()
         XCTAssertEqual(retrievedRequest1?.wrapped.config, config2)
 
-        let retrievedRequest2 = defaultQueue.nextRequest()
+        let retrievedRequest2 = await defaultQueue.nextRequest()
         XCTAssertNil(retrievedRequest2)
     }
 
-    func test_remove_requests_should_remove_every_request_matching_the_filter_in_the_uniquing_queue() {
+    func test_remove_requests_should_remove_every_request_matching_the_filter_in_the_uniquing_queue() async {
 
 
         let config0 = APIRequestConfig(method: .get, path: .path("fake_path1"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: [.onNetworkInterrupt]))
@@ -711,17 +703,12 @@ extension APIClientQueueTests {
         let config3 = APIRequestConfig(method: .get, path: .path("fake_path4"), queueingStrategy: APIRequestConfig.QueueingStrategy(synchronization: .barrier, retryPolicy: []))
         let request3 = APIClientQueueRequest(wrapping: APIRequest<Data>(config3), identifiers: "[{\"local\":\"4\"}]".data(using: .utf8))
 
-        uniquingQueue.append(request0)
-        uniquingQueue.append(request1)
-        uniquingQueue.append(request2)
-        uniquingQueue.append(request3)
+        await uniquingQueue.append(request0)
+        await uniquingQueue.append(request1)
+        await uniquingQueue.append(request2)
+        await uniquingQueue.append(request3)
 
-        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
-
-        let removedRequests = uniquingQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
+        let removedRequests = await uniquingQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
 
         // test correct requests were removed
         XCTAssertEqual(removedRequests.count, 2)
@@ -729,13 +716,13 @@ extension APIClientQueueTests {
         XCTAssertEqual(removedRequests.last?.wrapped.config, config3)
 
         // test remaining queue is correct
-        let retrievedRequest0 = uniquingQueue.nextRequest()
+        let retrievedRequest0 = await uniquingQueue.nextRequest()
         XCTAssertEqual(retrievedRequest0?.wrapped.config, config0)
 
-        let retrievedRequest1 = uniquingQueue.nextRequest()
+        let retrievedRequest1 = await uniquingQueue.nextRequest()
         XCTAssertEqual(retrievedRequest1?.wrapped.config, config2)
 
-        let retrievedRequest2 = uniquingQueue.nextRequest()
+        let retrievedRequest2 = await uniquingQueue.nextRequest()
         XCTAssertNil(retrievedRequest2)
     }
 }

--- a/LucidTests/Core/APIClientQueueTests.swift
+++ b/LucidTests/Core/APIClientQueueTests.swift
@@ -22,7 +22,6 @@ final class APIClientQueueTests: XCTestCase {
 
     // MARK: - Doubles
 
-    private var uniquingCacheDataQueue: AsyncTaskQueue!
     private var uniquingFunction: ((APIClientQueueRequest) -> String)!
 
     // MARK: - Subject
@@ -39,16 +38,14 @@ final class APIClientQueueTests: XCTestCase {
         uniquingQueueOrderingCache = DiskCacheSpy()
         uniquingQueueValueCache = DiskCacheSpy()
         queueProcessor = APIClientQueueProcessorSpy()
-        uniquingCacheDataQueue = AsyncTaskQueue()
 
         defaultQueue = APIClientQueue(cache: .default(DiskQueue(diskCache: defaultQueueCache.caching)),
                                       processor: queueProcessor)
 
         uniquingFunction = { $0.wrapped.config.path.description + "_key" }
+        let uniquingCache = APIClientQueue.Cache.UniquingCache(orderingSetCache: uniquingQueueOrderingCache.caching, valueCache: uniquingQueueValueCache.caching)
 
-        uniquingQueue = APIClientQueue(cache: .uniquing(uniquingQueueOrderingCache.caching,
-                                                        uniquingQueueValueCache.caching,
-                                                        uniquingCacheDataQueue,
+        uniquingQueue = APIClientQueue(cache: .uniquing(uniquingCache,
                                                         uniquingFunction),
                                        processor: queueProcessor)
     }
@@ -85,9 +82,8 @@ extension APIClientQueueTests {
     func test_uniquing_queue_sets_itself_as_delegate_of_processor() {
 
         let localQueueProcessor = APIClientQueueProcessorSpy()
-        let localQueue = APIClientQueue(cache: .uniquing(uniquingQueueOrderingCache.caching,
-                                                         uniquingQueueValueCache.caching,
-                                                         uniquingCacheDataQueue,
+        let uniquingCache = APIClientQueue.Cache.UniquingCache(orderingSetCache: uniquingQueueOrderingCache.caching, valueCache: uniquingQueueValueCache.caching)
+        let localQueue = APIClientQueue(cache: .uniquing(uniquingCache,
                                                          uniquingFunction),
                                         processor: localQueueProcessor)
 
@@ -224,7 +220,7 @@ extension APIClientQueueTests {
 
         await uniquingQueue.append(request)
 //        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
+//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 1)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -248,7 +244,7 @@ extension APIClientQueueTests {
 //        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
 //        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
+//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -279,7 +275,7 @@ extension APIClientQueueTests {
 //        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 //        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
-        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
+//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 3)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -310,7 +306,7 @@ extension APIClientQueueTests {
         await uniquingQueue.append(request)
 //        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
-        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
+//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 1)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -327,7 +323,7 @@ extension APIClientQueueTests {
 //        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
 //        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
-        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
+//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 2)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)

--- a/LucidTests/Core/APIClientQueueTests.swift
+++ b/LucidTests/Core/APIClientQueueTests.swift
@@ -102,7 +102,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
         await defaultQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 1)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request)
@@ -118,9 +117,6 @@ extension APIClientQueueTests {
         await defaultQueue.append(request0)
         await defaultQueue.append(request1)
 
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 2)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request0)
         XCTAssertEqual(defaultQueueCache.setInvocations[1].1, request1)
@@ -134,7 +130,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
 
         await defaultQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 1)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -147,9 +142,6 @@ extension APIClientQueueTests {
 
         await defaultQueue.append(request0)
         await defaultQueue.append(request1)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 2)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -167,7 +159,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 0)
 
         await defaultQueue.prepend(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 1)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request)
@@ -183,9 +174,6 @@ extension APIClientQueueTests {
         await defaultQueue.prepend(request0)
         await defaultQueue.prepend(request1)
 
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
         XCTAssertEqual(defaultQueueCache.setInvocations.count, 2)
         XCTAssertEqual(defaultQueueCache.setInvocations[0].1, request0)
         XCTAssertEqual(defaultQueueCache.setInvocations[1].1, request1)
@@ -198,9 +186,6 @@ extension APIClientQueueTests {
 
         await defaultQueue.prepend(request0)
         await defaultQueue.prepend(request1)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -219,8 +204,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations.count, 0)
 
         await uniquingQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 1)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -240,11 +223,6 @@ extension APIClientQueueTests {
 
         await uniquingQueue.append(request0)
         await uniquingQueue.append(request1)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
-//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -270,12 +248,6 @@ extension APIClientQueueTests {
         await uniquingQueue.append(request0)
         await uniquingQueue.append(request1)
         await uniquingQueue.append(request2)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-
-//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 3)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -304,9 +276,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
 
         await uniquingQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-
-//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 1)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -319,11 +288,6 @@ extension APIClientQueueTests {
 
         await uniquingQueue.append(request0)
         await uniquingQueue.append(request1)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
-//        try? await uniquingCacheDataQueue.enqueueBarrier { completion in completion() }
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 2)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
@@ -342,9 +306,6 @@ extension APIClientQueueTests {
         XCTAssertEqual(uniquingQueueValueCache.asyncSetInvocations.count, 0)
 
         await uniquingQueue.prepend(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 1)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -364,11 +325,6 @@ extension APIClientQueueTests {
 
         await uniquingQueue.prepend(request0)
         await uniquingQueue.prepend(request1)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
 
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
@@ -395,12 +351,6 @@ extension APIClientQueueTests {
         await uniquingQueue.prepend(request1)
         await uniquingQueue.prepend(request2)
 
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
-
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations.count, 2)
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].0, "APIClientQueue_uniquing_cache_key")
         XCTAssertEqual(uniquingQueueOrderingCache.asyncSetInvocations[0].1?.array, ["fake_path1_key"])
@@ -422,11 +372,6 @@ extension APIClientQueueTests {
         await uniquingQueue.prepend(request0)
         await uniquingQueue.prepend(request1)
 
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
-
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 0)
         XCTAssertEqual(queueProcessor.flushInvocations, 0)
     }
@@ -445,10 +390,6 @@ extension APIClientQueueTests {
         await defaultQueue.append(request0)
         await defaultQueue.append(request1)
         await defaultQueue.append(request2)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
         await defaultQueue.flush()
 
@@ -471,12 +412,6 @@ extension APIClientQueueTests {
         await uniquingQueue.append(request1)
         await uniquingQueue.append(request2)
 
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
-
         await uniquingQueue.flush()
 
         XCTAssertEqual(queueProcessor.didEnqueueNewRequestInvocations, 3)
@@ -493,7 +428,6 @@ extension APIClientQueueTests {
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         await defaultQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
 
         let retrievedRequest = await defaultQueue.nextRequest()
 
@@ -510,10 +444,6 @@ extension APIClientQueueTests {
         await defaultQueue.append(request0)
         await defaultQueue.append(request1)
         await defaultQueue.append(request2)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
 
         let retrievedRequest0 = await defaultQueue.nextRequest()
         XCTAssertEqual(request0, retrievedRequest0)
@@ -538,9 +468,6 @@ extension APIClientQueueTests {
         let request = APIClientQueueRequest(wrapping: APIRequest<Data>(method: .get, path: .path("fake_path")))
 
         await uniquingQueue.append(request)
-//        queueProcessor.prepareRequestInvocations[0].completion(request.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
 
         let retrievedRequest = await uniquingQueue.nextRequest()
 
@@ -559,13 +486,6 @@ extension APIClientQueueTests {
         await uniquingQueue.append(request1)
         await uniquingQueue.append(request2)
         await uniquingQueue.append(request3)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
-
-//        uniquingCacheDataQueue.sync { }
 
         let retrievedRequest0 = await uniquingQueue.nextRequest()
         XCTAssertEqual(request1, retrievedRequest0)
@@ -660,11 +580,6 @@ extension APIClientQueueTests {
         await defaultQueue.append(request1)
         await defaultQueue.append(request2)
         await defaultQueue.append(request3)
-
-//        queueProcessor.prepareRequestInvocations[0].completion(request0.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[1].completion(request1.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[2].completion(request2.wrapped.config)
-//        queueProcessor.prepareRequestInvocations[3].completion(request3.wrapped.config)
 
         let removedRequests = await defaultQueue.removeRequests(matching: { $0.wrapped.config.queueingStrategy.retryPolicy.contains(.onNetworkInterrupt) == false })
 

--- a/LucidTests/Doubles/APIClientQueueProcessorSpy.swift
+++ b/LucidTests/Doubles/APIClientQueueProcessorSpy.swift
@@ -27,10 +27,7 @@ public final class APIClientQueueProcessorSpy: APIClientQueueProcessing {
 
     public private(set) var abortRequestInvocations = [APIClientQueueRequest]()
 
-    public private(set) var prepareRequestInvocations = [(
-        requestConfig: APIRequestConfig,
-        completion: (APIRequestConfig) -> Void
-    )]()
+    public private(set) var prepareRequestInvocations = [APIRequestConfig]()
 
     // MARK: - Stubs
 
@@ -75,8 +72,9 @@ public final class APIClientQueueProcessorSpy: APIClientQueueProcessing {
 
     public var jsonCoderConfig = APIJSONCoderConfig()
 
-    public func prepareRequest(_ requestConfig: APIRequestConfig, completion: @escaping (APIRequestConfig) -> Void) {
-        prepareRequestInvocations.append((requestConfig, completion))
+    public func prepareRequest(_ requestConfig: APIRequestConfig) async -> APIRequestConfig {
+        prepareRequestInvocations.append(requestConfig)
+        return requestConfig
     }
 }
 
@@ -106,16 +104,16 @@ public final class APIClientQueueProcessorDelegateSpy: APIClientQueueProcessorDe
         // no-op
     }
 
-    public func prepend(_ request: APIClientQueueRequest) {
+    public func prepend(_ request: APIClientQueueRequest) async {
         prependInvocations.append((request))
     }
 
-    public func removeRequests(matching: @escaping (APIClientQueueRequest) -> Bool) -> [APIClientQueueRequest] {
+    public func removeRequests(matching: @escaping (APIClientQueueRequest) -> Bool) async -> [APIClientQueueRequest] {
         removeRequestsInvocations.append(matching)
         return removeRequestsStub
     }
 
-    public func nextRequest() -> APIClientQueueRequest? {
+    public func nextRequest() async -> APIClientQueueRequest? {
         nextRequestInvocations += 1
         return requestStub
     }


### PR DESCRIPTION
This PR converts the RemoteStore logic to async/await, which is the last part of the whole Lucid migration