### PR TITLE
iOS 17 Fix

### DIFF
--- a/Lucid/Core/APIClient.swift
+++ b/Lucid/Core/APIClient.swift
@@ -1021,7 +1021,7 @@ extension APIRequestConfig.QueryValue {
 
     public static let allowedCharacterSet: CharacterSet = {
         // https://tools.ietf.org/html/rfc3986#section-2.2
-        let reservedCharacterSet = CharacterSet(charactersIn: ":/?#[]@!$&'()+,;=")
+        let reservedCharacterSet = CharacterSet(charactersIn: ":/?#[]@!$&'()+,;")
         let urlQueryAllowedCharacterSet = CharacterSet.urlQueryAllowed
         return urlQueryAllowedCharacterSet.subtracting(reservedCharacterSet)
     }()


### PR DESCRIPTION
iOS 17 has some encoding changes that break the app. = was being encoded and this fixes that by including it in the allowed characters. Versions < iOS 17 seem to still work under this changes