### PR TITLE
[IPT-8858] Improve unit test api for async code

### DIFF
--- a/Lucid.xcodeproj/project.pbxproj
+++ b/Lucid.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		019C03042B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */; };
+		019C03052B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */; };
+		019C03062B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */; };
+		019C03072B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */; };
 		01ED569B29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
 		01ED569C29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
 		01ED569D29E9C3FA00C77548 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ED569A29E9C3FA00C77548 /* Async.swift */; };
@@ -424,6 +428,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		01ED569A29E9C3FA00C77548 /* Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		1907AD8224A6826400727F82 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		190ADC082458D71000D22F6D /* Lucid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lucid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1615,6 +1620,7 @@
 			isa = PBXGroup;
 			children = (
 				1987FA452554A7210057F1CC /* Combine.swift */,
+				019C03032B1A7D8600E4B65F /* AsyncExpectation.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2174,6 +2180,7 @@
 				190ADCDD2458D9A500D22F6D /* UserAccessValidatorSpy.swift in Sources */,
 				190ADCD92458D9A500D22F6D /* LoggerMock.swift in Sources */,
 				190ADCD82458D9A500D22F6D /* StoreSpy.swift in Sources */,
+				019C03042B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */,
 				190ADCDF2458D9A500D22F6D /* FakeStore.swift in Sources */,
 				190ADCD62458D9A500D22F6D /* GraphStub.swift in Sources */,
 				1922E27F25C345AB0038DD8F /* ManagedEntitySpy+CoreDataClass.swift in Sources */,
@@ -2291,6 +2298,7 @@
 				F4A7588D2914746F0046DE3F /* DiskCacheSpy.swift in Sources */,
 				F4A7588A2914746F0046DE3F /* StoreSpy.swift in Sources */,
 				F4A7587E2914746F0046DE3F /* ManagedEntityRelationshipSpy+CoreDataProperties.swift in Sources */,
+				019C03072B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */,
 				F4A758802914746F0046DE3F /* AnyEntitySpy.swift in Sources */,
 				F4A75891291474A20046DE3F /* Combine.swift in Sources */,
 				F4A758852914746F0046DE3F /* EntityRelationshipSpy.swift in Sources */,
@@ -2436,6 +2444,7 @@
 				F4A758B2291477A80046DE3F /* LoggerMock.swift in Sources */,
 				F4A758AD291477A80046DE3F /* DiskCacheSpy.swift in Sources */,
 				F4A758A8291477A80046DE3F /* APIClientQueueSpy.swift in Sources */,
+				019C03062B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */,
 				F4A7589F291477A70046DE3F /* APIClientSpy.swift in Sources */,
 				F4A758AB291477A80046DE3F /* EntitySpy.swift in Sources */,
 				F4A758B3291477A80046DE3F /* ManagedEntitySpy+CoreDataProperties.swift in Sources */,
@@ -2467,6 +2476,7 @@
 				F4A758D6291479460046DE3F /* APIClientQueueSchedulerSpy.swift in Sources */,
 				F4A758CD291479460046DE3F /* UserAccessValidatorSpy.swift in Sources */,
 				F4A758CE291479460046DE3F /* DiskCacheSpy.swift in Sources */,
+				019C03052B1A7D8600E4B65F /* AsyncExpectation.swift in Sources */,
 				F4A758D3291479460046DE3F /* LoggerMock.swift in Sources */,
 				F4A758DD291479460046DE3F /* EntityRelationshipSpy.swift in Sources */,
 				F4A758DA291479460046DE3F /* CoreManagerSpy.swift in Sources */,

--- a/LucidTestKit/Doubles/APIClientQueueSchedulerSpy.swift
+++ b/LucidTestKit/Doubles/APIClientQueueSchedulerSpy.swift
@@ -30,19 +30,19 @@ public final class APIClientQueueSchedulerSpy: APIClientQueueScheduling {
 
     public weak var delegate: APIClientQueueSchedulerDelegate?
 
-    public func didEnqueueNewRequest() {
+    public func didEnqueueNewRequest() async {
         didEnqueueNewRequestCallCount += 1
     }
 
-    public func flush() {
+    public func flush() async {
         flushCallCount += 1
     }
 
-    public func requestDidSucceed() {
+    public func requestDidSucceed() async {
         requestDidSucceedCallCount += 1
     }
 
-    public func requestDidFail() {
+    public func requestDidFail() async {
         requestDidFailCallCount += 1
     }
 }

--- a/LucidTestKit/Utils/AsyncExpectation.swift
+++ b/LucidTestKit/Utils/AsyncExpectation.swift
@@ -1,0 +1,192 @@
+//
+//  Async.swift
+//  Lucid
+//
+//  Created by Ezequiel Munz on 01/12/2023.
+//  Copyright © 2023 Scribd. All rights reserved.
+//
+
+import XCTest
+
+extension XCTestCase {
+    ///
+    /// Asynchronous assertion function that allows a future expectation to be checked.
+    /// The expression passed by argument will be checked every 10 miliseconds until it gets satisfied or the timeout is hit
+    /// If the expression is eventually satisfied, the test will pass
+    /// If the timeout is hit before the expression is satisfied, the test will fail
+    ///
+    /// This function is useful to test asynchronous code where the execution happens within multiple threads
+    ///
+    /// - parameters:
+    ///     - expression: The expression to be eventually satisfied
+    ///     - timeout: The timeout interval for the operation to finish
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func AsyncExpectation(expression: @escaping @autoclosure () async -> Bool, timeout: TimeInterval, file: StaticString = #file, line: UInt = #line) async {
+        await withTaskGroup(of: Void.self) { group in
+            // Timeout
+            group.addTask {
+                let timeoutValue = UInt64(1000000000 * timeout)
+                var elapsedTime: TimeInterval = Date().timeIntervalSince1970
+                try? await Task.sleep(nanoseconds: timeoutValue)
+                guard Task.isCancelled == false else { return }
+                elapsedTime = Date().timeIntervalSince1970 - elapsedTime
+                XCTFail("Timeout after: \(elapsedTime)", file: file, line: line)
+            }
+            // Assertion
+            group.addTask {
+                var success = false
+                var elapsedTime: TimeInterval = Date().timeIntervalSince1970
+                repeat {
+                    guard Task.isCancelled == false else { return }
+                    if await expression() {
+                        success = true
+                        elapsedTime = Date().timeIntervalSince1970 - elapsedTime
+                        XCTAssertTrue(success, "Comparison succeeded after \(elapsedTime) seconds", file: file, line: line)
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: NSEC_PER_MSEC * 10)
+                } while success == false
+            }
+
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
+    ///
+    /// Base assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssert(_ expression: @autoclosure () async throws -> Bool,
+                               _ message: @autoclosure () -> String = "",
+                               file: StaticString = #filePath,
+                               line: UInt = #line) async {
+        do {
+            let result = try await expression()
+            XCTAssert(result, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+
+    ///
+    /// True assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssertTrue(_ expression: @autoclosure () async throws -> Bool,
+                                   _ message: @autoclosure () -> String = "",
+                                   file: StaticString = #filePath,
+                                   line: UInt = #line) async {
+        do {
+            let result = try await expression()
+            XCTAssertTrue(result, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+
+    ///
+    /// False assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssertFalse(_ expression: @autoclosure () async throws -> Bool,
+                                    _ message: @autoclosure () -> String = "",
+                                    file: StaticString = #filePath,
+                                    line: UInt = #line) async {
+        do {
+            let result = try await expression()
+            XCTAssertFalse(result, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+
+    ///
+    /// Equality assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssertEqual<T>(_ expression1: @autoclosure () async throws -> T,
+                                       _ expression2: @autoclosure () async throws -> T,
+                                       _ message: @autoclosure () -> String = "",
+                                       file: StaticString = #filePath,
+                                       line: UInt = #line) async where T : Equatable {
+        do {
+            let result1 = try await expression1()
+            let result2 = try await expression2()
+            XCTAssertEqual(result1, result2, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+
+    ///
+    /// Nil assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssertNil<T>(_ expression: @autoclosure () async throws -> T?,
+                                     _ message: @autoclosure () -> String = "",
+                                     file: StaticString = #filePath,
+                                     line: UInt = #line) async {
+        do {
+            let result = try await expression()
+            XCTAssertNil(result, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+
+    ///
+    /// Not nil assertion function that takes an asynchronous expression
+    /// This option is viable to use within `actor` properties
+    ///
+    /// - parameters:
+    ///     - expression: Expression to be satisfied that returns a boolean
+    ///     - message: A message to display on the test
+    ///     - file: The file where the function is being called from (We don't need to overwrite it's value)
+    ///     - line: The line where the function is being called from (We don't need to overwrite it's value)
+    ///
+    public func XCTAsyncAssertNotNil<T>(_ expression: @autoclosure () async throws -> T?,
+                                        _ message: @autoclosure () -> String = "",
+                                        file: StaticString = #filePath,
+                                        line: UInt = #line) async {
+        do {
+            let result = try await expression()
+            XCTAssertNotNil(result, message(), file: file, line: line)
+        } catch {
+            XCTFail("Expression error: \(error)", file: file, line: line)
+        }
+    }
+}
+

--- a/LucidTests/Core/APIClientQueueDefaultSchedulerTests.swift
+++ b/LucidTests/Core/APIClientQueueDefaultSchedulerTests.swift
@@ -248,11 +248,8 @@ extension APIClientQueueDefaultSchedulerTests {
         let invocation = self.timerProvider.scheduledTimerInvocations[0]
         _ = invocation.target.perform(invocation.selector)
 
-        try? await Task.sleep(nanoseconds: 1000000)
-
         // ensure delegate was invoked
-        let processNextInvocationsEnd: [Void] = await delegate.processNextInvocations
-        XCTAssertEqual(processNextInvocationsEnd.count, 2)
+        await AsyncExpectation(expression: await self.delegate.processNextInvocations.count == 2, timeout: 5)
     }
 
     func testThatItInvalidatesTheTimerAndInvokesTheDelegateWhenDidEnqueueNewRequestIsCalledAndAPriorRequestFailedAndTheTimerHasNotFinished() async {

--- a/LucidTests/Core/CoreManagerTests.swift
+++ b/LucidTests/Core/CoreManagerTests.swift
@@ -944,11 +944,10 @@ final class CoreManagerTests: XCTestCase {
             let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
             XCTAssertEqual(result.entity?.identifier.value.remoteValue, 42)
 
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+            await AsyncExpectation(expression: self.remoteStoreSpy.identifierRecords.count == 1, timeout: 2)
+            await AsyncExpectation(expression: self.memoryStoreSpy.entityRecords.count == 1, timeout: 2)
 
-            XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.last?.identifier.value.remoteValue, 42)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -972,9 +971,8 @@ final class CoreManagerTests: XCTestCase {
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
 
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+            await AsyncExpectation(expression: self.memoryStoreSpy.entityRecords.count == 1, timeout: 1)
 
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -996,9 +994,6 @@ final class CoreManagerTests: XCTestCase {
             let result = try await manager.get(byID: EntitySpyIdentifier(value: .remote(42, nil)), in: context)
             XCTAssertNil(result.entity)
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
-
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
-
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -1023,9 +1018,8 @@ final class CoreManagerTests: XCTestCase {
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
 
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+            await AsyncExpectation(expression: self.memoryStoreSpy.entityRecords.count == 1, timeout: 1)
 
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 1)
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.first?.identifier.value.remoteValue, 42)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -1053,9 +1047,6 @@ final class CoreManagerTests: XCTestCase {
         } catch let error as ManagerError where error == .store(.api(.api(httpStatusCode: 500, errorPayload: nil, response: response))) {
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.count, 1)
             XCTAssertEqual(self.remoteStoreSpy.identifierRecords.first?.value.remoteValue, 42)
-
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
-
             XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 0)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -1154,6 +1145,7 @@ final class CoreManagerTests: XCTestCase {
                     }
                 }
 
+                // Timeout
                 group.addTask(priority: .low) {
                     try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
                 }
@@ -1195,6 +1187,7 @@ final class CoreManagerTests: XCTestCase {
                     }
                 }
 
+                // Timeout
                 group.addTask(priority: .low) {
                     try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
                 }
@@ -1826,12 +1819,11 @@ final class CoreManagerTests: XCTestCase {
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
 
-            try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+            await AsyncExpectation(expression: self.memoryStoreSpy.queryRecords.count == 2, timeout: 1)
+            await AsyncExpectation(expression: self.memoryStoreSpy.entityRecords.count == 2, timeout: 1)
+            await AsyncExpectation(expression: self.remoteStoreSpy.queryRecords.count == 1, timeout: 1)
 
             XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
-            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
-            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -1855,12 +1847,11 @@ final class CoreManagerTests: XCTestCase {
             XCTAssertEqual(result.array.last?.identifier.value.remoteValue, 42)
             XCTAssertEqual(result.count, 2)
 
-            try? await Task.sleep(nanoseconds: 50000)
+            await AsyncExpectation(expression: self.memoryStoreSpy.queryRecords.count == 2, timeout: 1)
+            await AsyncExpectation(expression: self.memoryStoreSpy.entityRecords.count == 2, timeout: 1)
+            await AsyncExpectation(expression: self.remoteStoreSpy.queryRecords.count == 1, timeout: 1)
 
             XCTAssertEqual(self.memoryStoreSpy.queryRecords.first?.filter, .identifier == .identifier(EntitySpyIdentifier(value: .remote(42, nil))))
-            XCTAssertEqual(self.memoryStoreSpy.queryRecords.count, 2)
-            XCTAssertEqual(self.memoryStoreSpy.entityRecords.count, 2)
-            XCTAssertEqual(self.remoteStoreSpy.queryRecords.count, 1)
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/LucidTests/Doubles/APIClientQueueProcessorSpy.swift
+++ b/LucidTests/Doubles/APIClientQueueProcessorSpy.swift
@@ -68,13 +68,21 @@ public final actor APIClientQueueProcessorSpy: APIClientQueueProcessing {
     }
 }
 
-public final class APIClientQueueProcessorDelegateSpy: APIClientQueueProcessorDelegate {
+public final actor APIClientQueueProcessorDelegateSpy: APIClientQueueProcessorDelegate {
 
     // MARK: - Stubs
 
     public var requestStub: APIClientQueueRequest?
 
+    public func setRequestStub(stub: APIClientQueueRequest?) {
+        self.requestStub = stub
+    }
+
     public var removeRequestsStub: [APIClientQueueRequest] = []
+
+    public func setRemoveRequestsStub(stub: [APIClientQueueRequest]) {
+        self.removeRequestsStub = stub
+    }
 
     // MARK: - Records
 

--- a/LucidTests/Stores/RecoverableStoreTests.swift
+++ b/LucidTests/Stores/RecoverableStoreTests.swift
@@ -45,24 +45,22 @@ final class RecoverableStoreTests: StoreTests {
         ).storing
     }
 
-    override func asyncTearDown(_ completion: @escaping () -> Void) {
-        Task {
-            let success = await StubCoreDataManagerFactory.shared.clearDatabase()
-            if success == false {
-                XCTFail("Did not clear database successfully.")
-            }
-
-            self.combineQueue.sync { }
-            self.relationshipCombineQueue.sync { }
-
-            self.innerMainStore = nil
-            self.innerRecoveryStore = nil
-            self.outerRecoverableStore = nil
-            self.combineQueue = nil
-            self.relationshipCombineQueue = nil
-
-            completion()
+    override func tearDown() async throws {
+        let success = await StubCoreDataManagerFactory.shared.clearDatabase()
+        if success == false {
+            XCTFail("Did not clear database successfully.")
         }
+
+        self.combineQueue.sync { }
+        self.relationshipCombineQueue.sync { }
+
+        self.innerMainStore = nil
+        self.innerRecoveryStore = nil
+        self.outerRecoverableStore = nil
+        self.combineQueue = nil
+        self.relationshipCombineQueue = nil
+
+        try await super.tearDown()
     }
 
     func waitForCombineQueues() {

--- a/LucidTests/Utils/CoreManagerPropertyTests.swift
+++ b/LucidTests/Utils/CoreManagerPropertyTests.swift
@@ -25,7 +25,7 @@ final class CoreManagerPropertyTests: XCTestCase {
 
                 group.addTask(priority: .low) {
                     let iterator = await property.stream.makeAsyncIterator()
-                    for try await value in iterator {
+                    for try await value in iterator where Task.isCancelled == false {
                         XCTAssertEqual(value, 5)
                         return
                     }
@@ -52,7 +52,7 @@ final class CoreManagerPropertyTests: XCTestCase {
                 group.addTask {
                     var count = 0
                     let iterator = await property.stream.makeAsyncIterator()
-                    for try await value in iterator {
+                    for try await value in iterator where Task.isCancelled == false {
                         if count == 0 {
                             XCTAssertEqual(value, nil)
                         } else if count == 1 {
@@ -94,7 +94,7 @@ final class CoreManagerPropertyTests: XCTestCase {
                 group.addTask {
                     var count = 0
                     let iterator = await property.stream.makeAsyncIterator()
-                    for try await value in iterator {
+                    for try await value in iterator where Task.isCancelled == false {
                         defer { count += 1 }
                         if count == 0 {
                             XCTAssertEqual(value, nil)
@@ -137,7 +137,7 @@ final class CoreManagerPropertyTests: XCTestCase {
         Task(priority: .high) {
             var count = 0
             let iterator = await property.stream.makeAsyncIterator()
-            for try await value in iterator {
+            for try await value in iterator where Task.isCancelled == false {
                 if count == 0 {
                     XCTAssertEqual(value, nil)
                 } else if count == 1 {
@@ -153,7 +153,7 @@ final class CoreManagerPropertyTests: XCTestCase {
         Task(priority: .high) {
             var count = 0
             let iterator = await property.stream.makeAsyncIterator()
-            for try await value in iterator {
+            for try await value in iterator where Task.isCancelled == false {
                 if count == 0 {
                     XCTAssertEqual(value, nil)
                 } else if count == 1 {


### PR DESCRIPTION
This PR adds some infrastructure to improve our Unit Test API over asynchronous code

- Adds a new function `AsyncExpectation()` that allows us to create an expectation that will "eventually" fulfill. This helps us saving some time when we need to "await" for some result to change (i.e Doubles Invocations).

This means that instead of having something like
```
try? await Task.sleep(NSEC_PER_SEC)

XCTAssertEqual(dependencies.someSpy.functionInvocations.count, 1)
``` 
we can write this code
```
await AsyncExpectation(expression: dependencies.someSpy.functionInvocations.count == 1, timeout: 1)
```
The advantage is that we'll only wait until the expression is satisfied instead of a fixed value (~5 miliseconds vs 1 sec)

- Adds conformance for the most common XCTAssertion functions to allow calling async expressions. This is valuable when testing using `actor` typed doubles

It adds:
- XCTAsyncAssert()
- XCTAsyncAssertTrue()
- XCTAsyncAssertFalse()
- XCTAssertEqual()
- XCTAsyncAssertNil()
- XCTAsyncAssertNotNil()

Usage:

```
await XCTAsyncAssert(await processDelegateSpy.prependInvocations.isEmpty == false)
await XCTAsyncAssertTrue(await processDelegateSpy.prependInvocations.isEmpty)
await XCTAsyncAssertFalse(await processDelegateSpy.prependInvocations.isEmpty)
await XCTAsyncAssertEqual(await processDelegateSpy.prependInvocations.count, 1)
await XCTAsyncAssertNil(await processDelegateSpy.prependInvocations.first)
await XCTAsyncAssertNotNil(await processDelegateSpy.prependInvocations.first)
```